### PR TITLE
io.Reader All The Things!  

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The most common usage scenario will be to use ```gofeed.FeedParser``` to parse a
 
 ```go
 fp := gofeed.NewFeedParser()
-feed := fp.ParseFeedURL("http://feeds.twit.tv/twit.xml")
+feed, _ := fp.ParseFeedURL("http://feeds.twit.tv/twit.xml")
 fmt.Println(feed.Title)
 ```
 
@@ -61,7 +61,17 @@ feedData := `<rss version="2.0">
 </channel>
 </rss>`
 fp := gofeed.NewFeedParser()
-feed := fp.ParseFeed(feedData)
+feed, _ := fp.ParseFeedString(feedData)
+fmt.Println(feed.Title)
+```
+
+##### Parse a feed from an io.Reader:
+
+```go
+file, _ := os.Open("/path/to/a/file.xml")
+defer file.Close()
+fp := gofeed.NewFeedParser()
+feed, _ := fp.ParseFeed(file)
 fmt.Println(feed.Title)
 ```
 
@@ -78,7 +88,7 @@ feedData := `<rss version="2.0">
 </channel>
 </rss>`
 fp := rss.Parser{}
-rssFeed := fp.ParseFeed(feedData)
+rssFeed, _ := fp.ParseFeedString(feedData)
 fmt.Println(rssFeed.WebMaster)
 ```
 
@@ -89,7 +99,7 @@ feedData := `<feed xmlns="http://www.w3.org/2005/Atom">
 <subtitle>Example Atom</subtitle>
 </feed>`
 fp := atom.Parser{}
-atomFeed := fp.ParseFeed(feedData)
+atomFeed, _ := fp.ParseFeedString(feedData)
 fmt.Println(atomFeed.Subtitle)
 ```
 
@@ -136,7 +146,7 @@ func main() {
     
     fp := gofeed.NewFeedParser()
     fp.RSSTrans = NewMyCustomTranslator()
-    feed := fp.ParseFeed(feedData)
+    feed, _ := fp.ParseFeedString(feedData)
     fmt.Println(feed.Author) // Valentine Wiggin
 }
 ```

--- a/atom/parser.go
+++ b/atom/parser.go
@@ -2,6 +2,7 @@ package atom
 
 import (
 	"encoding/base64"
+	"io"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -13,9 +14,8 @@ import (
 // Parser is an Atom Parser
 type Parser struct{}
 
-// ParseFeed parses a feed XML into an Atom feed
-func (ap *Parser) ParseFeed(feed string) (*Feed, error) {
-	p := xpp.NewXMLPullParser(strings.NewReader(feed), false)
+func (ap *Parser) ParseFeed(feed io.Reader) (*Feed, error) {
+	p := xpp.NewXMLPullParser(feed, false)
 
 	_, err := p.NextTag()
 	if err != nil {

--- a/atom/parser.go
+++ b/atom/parser.go
@@ -14,6 +14,7 @@ import (
 // Parser is an Atom Parser
 type Parser struct{}
 
+// ParseFeed parses an xml feed into an atom.Feed
 func (ap *Parser) ParseFeed(feed io.Reader) (*Feed, error) {
 	p := xpp.NewXMLPullParser(feed, false)
 
@@ -148,7 +149,10 @@ func (ap *Parser) parseRoot(p *xpp.XMLPullParser) (*Feed, error) {
 				}
 				atom.Entries = append(atom.Entries, result)
 			} else {
-				p.Skip()
+				err := p.Skip()
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
@@ -298,7 +302,10 @@ func (ap *Parser) parseEntry(p *xpp.XMLPullParser) (*Entry, error) {
 				}
 				entry.Content = result
 			} else {
-				p.Skip()
+				err := p.Skip()
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
@@ -445,7 +452,10 @@ func (ap *Parser) parseSource(p *xpp.XMLPullParser) (*Source, error) {
 				}
 				categories = append(categories, result)
 			} else {
-				p.Skip()
+				err := p.Skip()
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
@@ -534,7 +544,10 @@ func (ap *Parser) parsePerson(name string, p *xpp.XMLPullParser) (*Person, error
 				}
 				person.URI = result
 			} else {
-				p.Skip()
+				err := p.Skip()
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}

--- a/atom/parser_test.go
+++ b/atom/parser_test.go
@@ -1,10 +1,10 @@
 package atom_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,6 +12,8 @@ import (
 	"github.com/mmcdole/gofeed/atom"
 	"github.com/stretchr/testify/assert"
 )
+
+// Tests
 
 func TestAtomParser_ParseFeed(t *testing.T) {
 	files, _ := filepath.Glob("../testdata/parser/atom/*.xml")
@@ -23,12 +25,11 @@ func TestAtomParser_ParseFeed(t *testing.T) {
 
 		// Get actual source feed
 		ff := fmt.Sprintf("../testdata/parser/atom/%s.xml", name)
-		f, _ := os.Open(ff)
-		defer f.Close()
+		f, _ := ioutil.ReadFile(ff)
 
 		// Parse actual feed
 		fp := &atom.Parser{}
-		actual, _ := fp.ParseFeed(f)
+		actual, _ := fp.ParseFeed(bytes.NewReader(f))
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("../testdata/parser/atom/%s.json", name)
@@ -45,3 +46,5 @@ func TestAtomParser_ParseFeed(t *testing.T) {
 		}
 	}
 }
+
+// TODO: Examples

--- a/atom/parser_test.go
+++ b/atom/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,11 +23,12 @@ func TestAtomParser_ParseFeed(t *testing.T) {
 
 		// Get actual source feed
 		ff := fmt.Sprintf("../testdata/parser/atom/%s.xml", name)
-		f, _ := ioutil.ReadFile(ff)
+		f, _ := os.Open(ff)
+		defer f.Close()
 
 		// Parse actual feed
 		fp := &atom.Parser{}
-		actual, _ := fp.ParseFeed(string(f))
+		actual, _ := fp.ParseFeed(f)
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("../testdata/parser/atom/%s.json", name)

--- a/feedparser_test.go
+++ b/feedparser_test.go
@@ -84,6 +84,44 @@ func TestFeedParser_ParseFeed(t *testing.T) {
 	}
 }
 
+func TestFeedParser_ParseFeedString(t *testing.T) {
+	var feedTests = []struct {
+		file      string
+		feedType  string
+		feedTitle string
+		hasError  bool
+	}{
+		{"atom03_feed.xml", "atom", "Atom Title", false},
+		{"atom10_feed.xml", "atom", "Atom Title", false},
+		{"rss_feed.xml", "rss", "RSS Title", false},
+		{"rdf_feed.xml", "rss", "RDF Title", false},
+		{"unknown_feed.xml", "", "", true},
+		{"empty_feed.xml", "", "", true},
+	}
+
+	for _, test := range feedTests {
+		fmt.Printf("Testing %s... ", test.file)
+
+		// Get feed content
+		path := fmt.Sprintf("testdata/parser/feed/%s", test.file)
+		f, _ := ioutil.ReadFile(path)
+
+		// Get actual value
+		fp := gofeed.NewFeedParser()
+		feed, err := fp.ParseFeedString(string(f))
+
+		if test.hasError {
+			assert.NotNil(t, err)
+			assert.Nil(t, feed)
+		} else {
+			assert.NotNil(t, feed)
+			assert.Nil(t, err)
+			assert.Equal(t, feed.FeedType, test.feedType)
+			assert.Equal(t, feed.Title, test.feedTitle)
+		}
+	}
+}
+
 func TestFeedParser_ParseFeedURL_Success(t *testing.T) {
 	var feedTests = []struct {
 		file      string

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -2,6 +2,7 @@ package rss
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/mmcdole/gofeed/extensions"
@@ -9,12 +10,11 @@ import (
 	"github.com/mmcdole/goxpp"
 )
 
-// Parser is an RSS Parser
+// Parser is a RSS Parser
 type Parser struct{}
 
-// ParseFeed parses a feed XML into an RSS Feed
-func (rp *Parser) ParseFeed(feed string) (*Feed, error) {
-	p := xpp.NewXMLPullParser(strings.NewReader(feed), false)
+func (rp *Parser) ParseFeed(feed io.Reader) (*Feed, error) {
+	p := xpp.NewXMLPullParser(feed, false)
 
 	_, err := p.NextTag()
 	if err != nil {

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -13,6 +13,7 @@ import (
 // Parser is a RSS Parser
 type Parser struct{}
 
+// ParseFeed parses an xml feed into an rss.Feed
 func (rp *Parser) ParseFeed(feed io.Reader) (*Feed, error) {
 	p := xpp.NewXMLPullParser(feed, false)
 

--- a/rss/parser_test.go
+++ b/rss/parser_test.go
@@ -1,10 +1,10 @@
 package rss_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -23,12 +23,11 @@ func TestRSSParser_ParseFeed(t *testing.T) {
 
 		// Get actual source feed
 		ff := fmt.Sprintf("../testdata/parser/rss/%s.xml", name)
-		f, _ := os.Open(ff)
-		defer f.Close()
+		f, _ := ioutil.ReadFile(ff)
 
 		// Parse actual feed
 		fp := &rss.Parser{}
-		actual, _ := fp.ParseFeed(f)
+		actual, _ := fp.ParseFeed(bytes.NewReader(f))
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("../testdata/parser/rss/%s.json", name)
@@ -45,3 +44,5 @@ func TestRSSParser_ParseFeed(t *testing.T) {
 		}
 	}
 }
+
+// TODO: Examples

--- a/rss/parser_test.go
+++ b/rss/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,11 +23,12 @@ func TestRSSParser_ParseFeed(t *testing.T) {
 
 		// Get actual source feed
 		ff := fmt.Sprintf("../testdata/parser/rss/%s.xml", name)
-		f, _ := ioutil.ReadFile(ff)
+		f, _ := os.Open(ff)
+		defer f.Close()
 
 		// Parse actual feed
 		fp := &rss.Parser{}
-		actual, _ := fp.ParseFeed(string(f))
+		actual, _ := fp.ParseFeed(f)
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("../testdata/parser/rss/%s.json", name)

--- a/translator.go
+++ b/translator.go
@@ -1,6 +1,7 @@
 package gofeed
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -10,16 +11,10 @@ import (
 	"github.com/mmcdole/gofeed/rss"
 )
 
-// AtomTranslator converts an atom.Feed struct
+// Translator converts a particular feed (atom.Feed or rss.Feed)
 // into the generic Feed struct
-type AtomTranslator interface {
-	Translate(atom *atom.Feed) *Feed
-}
-
-// RSSTranslator converts an rss.Feed struct
-// into the generic Feed struct
-type RSSTranslator interface {
-	Translate(rss *rss.Feed) *Feed
+type Translator interface {
+	Translate(feed interface{}) (*Feed, error)
 }
 
 // DefaultRSSTranslator converts an rss.Feed struct
@@ -32,27 +27,32 @@ type DefaultRSSTranslator struct{}
 
 // Translate converts an RSS feed into the universal
 // feed type.
-func (t *DefaultRSSTranslator) Translate(rss *rss.Feed) *Feed {
-	feed := &Feed{}
-	feed.Title = t.translateFeedTitle(rss)
-	feed.Description = t.translateFeedDescription(rss)
-	feed.Link = t.translateFeedLink(rss)
-	feed.FeedLink = t.translateFeedFeedLink(rss)
-	feed.Updated = t.translateFeedUpdated(rss)
-	feed.UpdatedParsed = t.translateFeedUpdatedParsed(rss)
-	feed.Published = t.translateFeedPublished(rss)
-	feed.PublishedParsed = t.translateFeedPublishedParsed(rss)
-	feed.Author = t.translateFeedAuthor(rss)
-	feed.Language = t.translateFeedLanguage(rss)
-	feed.Image = t.translateFeedImage(rss)
-	feed.Copyright = t.translateFeedCopyright(rss)
-	feed.Generator = t.translateFeedGenerator(rss)
-	feed.Categories = t.translateFeedCategories(rss)
-	feed.Items = t.translateFeedItems(rss)
-	feed.Extensions = rss.Extensions
-	feed.FeedVersion = rss.Version
-	feed.FeedType = "rss"
-	return feed
+func (t *DefaultRSSTranslator) Translate(feed interface{}) (*Feed, error) {
+	rss, found := feed.(*rss.Feed)
+	if !found {
+		return nil, fmt.Errorf("Feed did not match expected type of *rss.Feed")
+	}
+
+	result := &Feed{}
+	result.Title = t.translateFeedTitle(rss)
+	result.Description = t.translateFeedDescription(rss)
+	result.Link = t.translateFeedLink(rss)
+	result.FeedLink = t.translateFeedFeedLink(rss)
+	result.Updated = t.translateFeedUpdated(rss)
+	result.UpdatedParsed = t.translateFeedUpdatedParsed(rss)
+	result.Published = t.translateFeedPublished(rss)
+	result.PublishedParsed = t.translateFeedPublishedParsed(rss)
+	result.Author = t.translateFeedAuthor(rss)
+	result.Language = t.translateFeedLanguage(rss)
+	result.Image = t.translateFeedImage(rss)
+	result.Copyright = t.translateFeedCopyright(rss)
+	result.Generator = t.translateFeedGenerator(rss)
+	result.Categories = t.translateFeedCategories(rss)
+	result.Items = t.translateFeedItems(rss)
+	result.Extensions = rss.Extensions
+	result.FeedVersion = rss.Version
+	result.FeedType = "rss"
+	return result, nil
 }
 
 func (t *DefaultRSSTranslator) translateFeedItem(rssItem *rss.Item) (item *Item) {
@@ -414,25 +414,30 @@ type DefaultAtomTranslator struct{}
 
 // Translate converts an Atom feed into the universal
 // feed type.
-func (t *DefaultAtomTranslator) Translate(atom *atom.Feed) *Feed {
-	feed := &Feed{}
-	feed.Title = t.translateFeedTitle(atom)
-	feed.Description = t.translateFeedDescription(atom)
-	feed.Link = t.translateFeedLink(atom)
-	feed.FeedLink = t.translateFeedFeedLink(atom)
-	feed.Updated = t.translateFeedUpdated(atom)
-	feed.UpdatedParsed = t.translateFeedUpdatedParsed(atom)
-	feed.Author = t.translateFeedAuthor(atom)
-	feed.Language = t.translateFeedLanguage(atom)
-	feed.Image = t.translateFeedImage(atom)
-	feed.Copyright = t.translateFeedCopyright(atom)
-	feed.Categories = t.translateFeedCategories(atom)
-	feed.Generator = t.translateFeedGenerator(atom)
-	feed.Items = t.translateFeedItems(atom)
-	feed.Extensions = atom.Extensions
-	feed.FeedVersion = atom.Version
-	feed.FeedType = "atom"
-	return feed
+func (t *DefaultAtomTranslator) Translate(feed interface{}) (*Feed, error) {
+	atom, found := feed.(*atom.Feed)
+	if !found {
+		return nil, fmt.Errorf("Feed did not match expected type of *atom.Feed")
+	}
+
+	result := &Feed{}
+	result.Title = t.translateFeedTitle(atom)
+	result.Description = t.translateFeedDescription(atom)
+	result.Link = t.translateFeedLink(atom)
+	result.FeedLink = t.translateFeedFeedLink(atom)
+	result.Updated = t.translateFeedUpdated(atom)
+	result.UpdatedParsed = t.translateFeedUpdatedParsed(atom)
+	result.Author = t.translateFeedAuthor(atom)
+	result.Language = t.translateFeedLanguage(atom)
+	result.Image = t.translateFeedImage(atom)
+	result.Copyright = t.translateFeedCopyright(atom)
+	result.Categories = t.translateFeedCategories(atom)
+	result.Generator = t.translateFeedGenerator(atom)
+	result.Items = t.translateFeedItems(atom)
+	result.Extensions = atom.Extensions
+	result.FeedVersion = atom.Version
+	result.FeedType = "atom"
+	return result, nil
 }
 
 func (t *DefaultAtomTranslator) translateFeedItem(entry *atom.Entry) (item *Item) {

--- a/translator_test.go
+++ b/translator_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,13 +25,14 @@ func TestDefaultRSSTranslator_Translate(t *testing.T) {
 
 		// Get actual source feed
 		ff := fmt.Sprintf("testdata/translator/rss/%s.xml", name)
-		f, _ := ioutil.ReadFile(ff)
+		f, _ := os.Open(ff)
+		defer f.Close()
 
 		// Parse actual feed
 		translator := &gofeed.DefaultRSSTranslator{}
 		fp := &rss.Parser{}
-		rssFeed, _ := fp.ParseFeed(string(f))
-		actual := translator.Translate(rssFeed)
+		rssFeed, _ := fp.ParseFeed(f)
+		actual, _ := translator.Translate(rssFeed)
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("testdata/translator/rss/%s.json", name)
@@ -58,13 +60,14 @@ func TestDefaultAtomTranslator_Translate(t *testing.T) {
 
 		// Get actual source feed
 		ff := fmt.Sprintf("testdata/translator/atom/%s.xml", name)
-		f, _ := ioutil.ReadFile(ff)
+		f, _ := os.Open(ff)
+		defer f.Close()
 
 		// Parse actual feed
 		translator := &gofeed.DefaultAtomTranslator{}
 		fp := &atom.Parser{}
-		atomFeed, _ := fp.ParseFeed(string(f))
-		actual := translator.Translate(atomFeed)
+		atomFeed, _ := fp.ParseFeed(f)
+		actual, _ := translator.Translate(atomFeed)
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("testdata/translator/atom/%s.json", name)

--- a/translator_test.go
+++ b/translator_test.go
@@ -50,6 +50,13 @@ func TestDefaultRSSTranslator_Translate(t *testing.T) {
 	}
 }
 
+func TestDefaultRSSTranslator_Translate_WrongType(t *testing.T) {
+	translator := &gofeed.DefaultRSSTranslator{}
+	af, err := translator.Translate("wrong type")
+	assert.Nil(t, af)
+	assert.NotNil(t, err)
+}
+
 func TestDefaultAtomTranslator_Translate(t *testing.T) {
 	files, _ := filepath.Glob("testdata/translator/atom/*.xml")
 	for _, f := range files {
@@ -83,4 +90,11 @@ func TestDefaultAtomTranslator_Translate(t *testing.T) {
 			fmt.Printf("Failed\n")
 		}
 	}
+}
+
+func TestDefaultAtomTranslator_Translate_WrongType(t *testing.T) {
+	translator := &gofeed.DefaultAtomTranslator{}
+	af, err := translator.Translate("wrong type")
+	assert.Nil(t, af)
+	assert.NotNil(t, err)
 }


### PR DESCRIPTION
![](https://cdn.meme.am/instances2/500x/5148804.jpg)

Moved to using `io.Reader` instead of strings by default to prevent having to have the entire feed in memory while we are parsing it.

Also made some minor modifications to the Translator interface.

This should hopefully fully address #14 