### PR TITLE
Ignore tokens between start/end tags

### DIFF
--- a/atom/parser.go
+++ b/atom/parser.go
@@ -45,7 +45,7 @@ func (ap *Parser) parseRoot(p *xpp.XMLPullParser) (*Feed, error) {
 	extensions := ext.Extensions{}
 
 	for {
-		tok, err := p.NextTag()
+		tok, err := shared.NextTag(p)
 		if err != nil {
 			return nil, err
 		}
@@ -199,7 +199,7 @@ func (ap *Parser) parseEntry(p *xpp.XMLPullParser) (*Entry, error) {
 	extensions := ext.Extensions{}
 
 	for {
-		tok, err := p.NextTag()
+		tok, err := shared.NextTag(p)
 		if err != nil {
 			return nil, err
 		}
@@ -354,7 +354,7 @@ func (ap *Parser) parseSource(p *xpp.XMLPullParser) (*Source, error) {
 	extensions := ext.Extensions{}
 
 	for {
-		tok, err := p.NextTag()
+		tok, err := shared.NextTag(p)
 		if err != nil {
 			return nil, err
 		}
@@ -512,7 +512,7 @@ func (ap *Parser) parsePerson(name string, p *xpp.XMLPullParser) (*Person, error
 	person := &Person{}
 
 	for {
-		tok, err := p.NextTag()
+		tok, err := shared.NextTag(p)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/shared/parseutils.go
+++ b/internal/shared/parseutils.go
@@ -35,6 +35,29 @@ func FindRoot(p *xpp.XMLPullParser) (event xpp.XMLEventType, err error) {
 	return
 }
 
+// NextTag iterates through the tokens until it reaches a StartTag or EndTag
+// It is similar to goxpp's NextTag method except it wont throw an error if
+// the next immediate token isnt a Start/EndTag.  Instead, it will continue to
+// consume tokens until it hits a Start/EndTag or EndDocument.
+func NextTag(p *xpp.XMLPullParser) (event xpp.XMLEventType, err error) {
+	for {
+		event, err = p.Next()
+		if err != nil {
+			return event, err
+		}
+
+		if event == xpp.StartTag || event == xpp.EndTag {
+			break
+		}
+
+		if event == xpp.EndDocument {
+			return event, fmt.Errorf("Failed to find NextTag before reaching the end of the document.")
+		}
+
+	}
+	return
+}
+
 // ParseText is a helper function for parsing the text
 // from the current element of the XMLPullParser.
 // This function can handle parsing naked XML text from

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -43,7 +43,7 @@ func (rp *Parser) parseRoot(p *xpp.XMLPullParser) (*Feed, error) {
 	ver := rp.parseVersion(p)
 
 	for {
-		tok, err := p.NextTag()
+		tok, err := shared.NextTag(p)
 		if err != nil {
 			return nil, err
 		}
@@ -65,7 +65,6 @@ func (rp *Parser) parseRoot(p *xpp.XMLPullParser) (*Feed, error) {
 			if name == "channel" {
 				channel, err = rp.parseChannel(p)
 				if err != nil {
-					fmt.Printf("error in channel: %s\n", err)
 					return nil, err
 				}
 			} else if name == "item" {
@@ -130,7 +129,7 @@ func (rp *Parser) parseChannel(p *xpp.XMLPullParser) (rss *Feed, err error) {
 	categories := []*Category{}
 
 	for {
-		tok, err := p.NextTag()
+		tok, err := shared.NextTag(p)
 		if err != nil {
 			return nil, err
 		}
@@ -321,7 +320,7 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 	categories := []*Category{}
 
 	for {
-		tok, err := p.NextTag()
+		tok, err := shared.NextTag(p)
 		if err != nil {
 			return nil, err
 		}
@@ -486,7 +485,7 @@ func (rp *Parser) parseImage(p *xpp.XMLPullParser) (image *Image, err error) {
 	image = &Image{}
 
 	for {
-		tok, err := p.NextTag()
+		tok, err := shared.NextTag(p)
 		if err != nil {
 			return image, err
 		}
@@ -598,7 +597,7 @@ func (rp *Parser) parseTextInput(p *xpp.XMLPullParser) (*TextInput, error) {
 	ti := &TextInput{}
 
 	for {
-		tok, err := p.NextTag()
+		tok, err := shared.NextTag(p)
 		if err != nil {
 			return nil, err
 		}
@@ -655,7 +654,7 @@ func (rp *Parser) parseSkipHours(p *xpp.XMLPullParser) ([]string, error) {
 	hours := []string{}
 
 	for {
-		tok, err := p.NextTag()
+		tok, err := shared.NextTag(p)
 		if err != nil {
 			return nil, err
 		}
@@ -693,7 +692,7 @@ func (rp *Parser) parseSkipDays(p *xpp.XMLPullParser) ([]string, error) {
 	days := []string{}
 
 	for {
-		tok, err := p.NextTag()
+		tok, err := shared.NextTag(p)
 		if err != nil {
 			return nil, err
 		}
@@ -735,7 +734,7 @@ func (rp *Parser) parseCloud(p *xpp.XMLPullParser) (*Cloud, error) {
 	cloud.RegisterProcedure = p.Attribute("registerProcedure")
 	cloud.Protocol = p.Attribute("protocol")
 
-	p.NextTag()
+	shared.NextTag(p)
 
 	if err := p.Expect(xpp.EndTag, "cloud"); err != nil {
 		return nil, err


### PR DESCRIPTION
This should solve #38 where an illformed feed had random text between tags in an item.  These will now be skipped/ignored.