### PR TITLE
add support for numeric character reference in character data

### DIFF
--- a/atom/parser.go
+++ b/atom/parser.go
@@ -667,12 +667,12 @@ func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
 	if lowerType == "text" ||
 		strings.HasPrefix(lowerType, "text/") ||
 		(lowerType == "" && lowerMode == "") {
-		result = shared.DecodeEntities(result)
+		result, err = shared.DecodeEntities(result)
 	} else if strings.Contains(lowerType, "xhtml") {
 		result = ap.stripWrappingDiv(result)
 	} else if lowerType == "html" {
 		result = ap.stripWrappingDiv(result)
-		result = shared.DecodeEntities(result)
+		result, err = shared.DecodeEntities(result)
 	} else {
 		decodedStr, err := base64.StdEncoding.DecodeString(result)
 		if err == nil {
@@ -680,7 +680,7 @@ func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
 		}
 	}
 
-	return result, nil
+	return result, err
 }
 
 func (ap *Parser) parseLanguage(p *xpp.XMLPullParser) string {

--- a/internal/shared/parseutils.go
+++ b/internal/shared/parseutils.go
@@ -1,8 +1,11 @@
 package shared
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/mmcdole/goxpp"
@@ -13,6 +16,9 @@ var (
 	nameEmailRgx = regexp.MustCompile(`^([^@]+)\s+\(([^@]+@[^)]+)\)$`)
 	nameOnlyRgx  = regexp.MustCompile(`^([^@()]+)$`)
 	emailOnlyRgx = regexp.MustCompile(`^([^@()]+@[^@()]+)$`)
+
+	TruncatedEntity         = errors.New("truncated entity")
+	InvalidNumericReference = errors.New("invalid numeric reference")
 )
 
 // FindRoot iterates through the tokens of an xml document until
@@ -83,19 +89,84 @@ func ParseText(p *xpp.XMLPullParser) (string, error) {
 		return result, nil
 	}
 
-	result = DecodeEntities(result)
-	return result, nil
+	return DecodeEntities(result)
 }
 
 // DecodeEntities decodes escaped XML entities
 // in a string and returns the unescaped string
-func DecodeEntities(str string) string {
-	str = strings.Replace(str, "&lt;", "<", -1)
-	str = strings.Replace(str, "&gt;", ">", -1)
-	str = strings.Replace(str, "&quot;", "\"", -1)
-	str = strings.Replace(str, "&apos;", "'", -1)
-	str = strings.Replace(str, "&amp;", "&", -1)
-	return str
+func DecodeEntities(str string) (string, error) {
+	data := []byte(str)
+	buf := bytes.NewBuffer([]byte{})
+
+	for len(data) > 0 {
+		// Find the next entity
+		idx := bytes.IndexByte(data, '&')
+		if idx == -1 {
+			buf.Write(data)
+			break
+		}
+
+		// Write and skip everything before it
+		buf.Write(data[:idx])
+		data = data[idx+1:]
+
+		if len(data) == 0 {
+			return "", TruncatedEntity
+		}
+
+		// Find the end of the entity
+		end := bytes.IndexByte(data, ';')
+		if end == -1 {
+			return "", TruncatedEntity
+		}
+
+		if data[0] == '#' {
+			// Numerical character reference
+			var str string
+			base := 10
+
+			if len(data) > 1 && data[1] == 'x' {
+				str = string(data[2:end])
+				base = 16
+			} else {
+				str = string(data[1:end])
+			}
+
+			i, err := strconv.ParseUint(str, base, 32)
+			if err != nil {
+				return "", InvalidNumericReference
+			}
+
+			buf.WriteRune(rune(i))
+		} else {
+			// Predefined entity
+			name := string(data[:end])
+
+			var c byte
+			switch name {
+			case "lt":
+				c = '<'
+			case "gt":
+				c = '>'
+			case "quot":
+				c = '"'
+			case "apos":
+				c = '\''
+			case "amp":
+				c = '&'
+			default:
+				return "", fmt.Errorf("unknown predefined "+
+					"entity &%s;", name)
+			}
+
+			buf.WriteByte(c)
+		}
+
+		// Skip the entity
+		data = data[end+1:]
+	}
+
+	return buf.String(), nil
 }
 
 // ParseNameAddress parses name/email strings commonly

--- a/internal/shared/parseutils_test.go
+++ b/internal/shared/parseutils_test.go
@@ -1,0 +1,55 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeEntities(t *testing.T) {
+	tests := []struct {
+		str string
+		res string
+	}{
+		{"", ""},
+		{"foo", "foo"},
+
+		{"&lt;foo&gt;", "<foo>"},
+		{"a &quot;b&quot; &apos;c&apos;", "a \"b\" 'c'"},
+		{"foo &amp;&amp; bar", "foo && bar"},
+
+		{"&#34;foo&#34;", "\"foo\""},
+		{"&#x61;&#x062;&#x0063;", "abc"},
+		{"r&#xe9;sum&#x00E9;", "résumé"},
+	}
+
+	for _, test := range tests {
+		res, err := DecodeEntities(test.str)
+		assert.Nil(t, err, "cannot decode %q", test.str)
+		assert.Equal(t, res, test.res,
+			"%q was decoded to %q instead of %q",
+			test.str, res, test.res)
+	}
+}
+
+func TestDecodeEntitiesInvalid(t *testing.T) {
+	tests := []string{
+		// Predefined entities
+		"&",     // truncated
+		"&foo",  // truncated
+		"&foo;", // unknown
+		"&lt",   // known but truncated
+
+		// Numerical character references
+		"&#",      // truncated
+		"&#;",     // missing number
+		"&#x;",    // missing hexadecimal number
+		"&#12a;",  // invalid decimal number
+		"&#xfoo;", // invalid hexadecimal number
+	}
+
+	for _, test := range tests {
+		res, err := DecodeEntities(test)
+		assert.NotNil(t, err, "%q was decoded to %q", test, res)
+	}
+}


### PR DESCRIPTION
Fix #64.

With this patch, `DecodeEntities` now decodes both predefined entities and numeric character references. I had to make a few small changes since the function can now fail if it contains invalid entities.

I also added tests for the function.