### PR TITLE
Remove unused pkg fmt

### DIFF
--- a/internal/shared/charsetconv.go
+++ b/internal/shared/charsetconv.go
@@ -1,7 +1,6 @@
 package shared
 
 import (
-	"fmt"
 	"io"
 
 	"golang.org/x/net/html/charset"


### PR DESCRIPTION
This removes the unused but imported package fmt. Currently this throws the
error `imported and not used: "fmt"`.

Thanks!