### PR TITLE
Remember to close non-2xx responses

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -73,6 +73,16 @@ func (f *Parser) Parse(feed io.Reader) (*Feed, error) {
 func (f *Parser) ParseURL(feedURL string) (feed *Feed, err error) {
 	client := f.httpClient()
 	resp, err := client.Get(feedURL)
+
+	if resp != nil {
+		defer func() {
+			ce := resp.Body.Close()
+			if ce != nil {
+				err = ce
+			}
+		}()
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -84,12 +94,6 @@ func (f *Parser) ParseURL(feedURL string) (feed *Feed, err error) {
 		}
 	}
 
-	defer func() {
-		ce := resp.Body.Close()
-		if ce != nil {
-			err = ce
-		}
-	}()
 	return f.Parse(resp.Body)
 }
 

--- a/parser.go
+++ b/parser.go
@@ -74,6 +74,10 @@ func (f *Parser) ParseURL(feedURL string) (feed *Feed, err error) {
 	client := f.httpClient()
 	resp, err := client.Get(feedURL)
 
+	if err != nil {
+		return nil, err
+	}
+
 	if resp != nil {
 		defer func() {
 			ce := resp.Body.Close()
@@ -81,10 +85,6 @@ func (f *Parser) ParseURL(feedURL string) (feed *Feed, err error) {
 				err = ce
 			}
 		}()
-	}
-
-	if err != nil {
-		return nil, err
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {


### PR DESCRIPTION
I'm using gofeed to constantly poll some Atom/RSS feeds. There was a memory leak in my project caused by HTTP responses in this library not being closed: I was using `ParseURL`. It turns out any non 2xx response was leaking, because `Close()` was not being called on it.

This PR fixes this and also closes responses even if there was a non-nil error. The presence of an `err` does not mean an absence of `resp`, as redirection failures will produce both `err` and `resp` as non-nil.
