### PR TITLE
Add Timeout to httpClient

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/mmcdole/gofeed/atom"
 	"github.com/mmcdole/gofeed/rss"
@@ -140,6 +141,8 @@ func (f *Parser) httpClient() *http.Client {
 	if f.Client != nil {
 		return f.Client
 	}
-	f.Client = &http.Client{}
+	f.Client = &http.Client{
+		Timeout: time.Duration(15 * time.Second),
+	}
 	return f.Client
 }


### PR DESCRIPTION
Using a client without a timeout can be leak file pointers.
A more thorough discussion can be found at:
https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
The timeout is set to an arbitrary 15 seconds. Although Parse(io.Reader)
decuples the parser from the request handler (allowing the use of a custom
client), the default client should at least have a naive timeout.