### PR TITLE
Extension parsing w/ consecutive text nodes

### DIFF
--- a/extensions/itunes_test.go
+++ b/extensions/itunes_test.go
@@ -1,0 +1,46 @@
+package ext_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mmcdole/gofeed"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestITunes_Extensions(t *testing.T) {
+	files, _ := filepath.Glob("../testdata/extensions/itunes/*.xml")
+	for _, f := range files {
+		base := filepath.Base(f)
+		name := strings.TrimSuffix(base, filepath.Ext(base))
+
+		fmt.Printf("Testing %s... ", name)
+
+		// Get actual source feed
+		ff := fmt.Sprintf("../testdata/extensions/itunes/%s.xml", name)
+		f, _ := ioutil.ReadFile(ff)
+
+		// Parse actual feed
+		fp := gofeed.NewParser()
+		actual, _ := fp.Parse(bytes.NewReader(f))
+
+		// Get json encoded expected feed result
+		ef := fmt.Sprintf("../testdata/extensions/itunes/%s.json", name)
+		e, _ := ioutil.ReadFile(ef)
+
+		// Unmarshal expected feed
+		expected := &gofeed.Feed{}
+		json.Unmarshal(e, &expected)
+
+		if assert.Equal(t, expected, actual, "Feed file %s.xml did not match expected output %s.json", name, name) {
+			fmt.Printf("OK\n")
+		} else {
+			fmt.Printf("Failed\n")
+		}
+	}
+}

--- a/feed.go
+++ b/feed.go
@@ -11,25 +11,27 @@ import (
 // and rss.Feed gets translated to. It represents
 // a web feed.
 type Feed struct {
-	Title           string            `json:"title,omitempty"`
-	Description     string            `json:"description,omitempty"`
-	Link            string            `json:"link,omitempty"`
-	FeedLink        string            `json:"feedLink,omitempty"`
-	Updated         string            `json:"updated,omitempty"`
-	UpdatedParsed   *time.Time        `json:"updatedParsed,omitempty"`
-	Published       string            `json:"published,omitempty"`
-	PublishedParsed *time.Time        `json:"publishedParsed,omitempty"`
-	Author          *Person           `json:"author,omitempty"`
-	Language        string            `json:"language,omitempty"`
-	Image           *Image            `json:"image,omitempty"`
-	Copyright       string            `json:"copyright,omitempty"`
-	Generator       string            `json:"generator,omitempty"`
-	Categories      []string          `json:"categories,omitempty"`
-	Extensions      ext.Extensions    `json:"extensions,omitempty"`
-	Custom          map[string]string `json:"custom,omitempty"`
-	Items           []*Item           `json:"items"`
-	FeedType        string            `json:"feedType"`
-	FeedVersion     string            `json:"feedVersion"`
+	Title           string                   `json:"title,omitempty"`
+	Description     string                   `json:"description,omitempty"`
+	Link            string                   `json:"link,omitempty"`
+	FeedLink        string                   `json:"feedLink,omitempty"`
+	Updated         string                   `json:"updated,omitempty"`
+	UpdatedParsed   *time.Time               `json:"updatedParsed,omitempty"`
+	Published       string                   `json:"published,omitempty"`
+	PublishedParsed *time.Time               `json:"publishedParsed,omitempty"`
+	Author          *Person                  `json:"author,omitempty"`
+	Language        string                   `json:"language,omitempty"`
+	Image           *Image                   `json:"image,omitempty"`
+	Copyright       string                   `json:"copyright,omitempty"`
+	Generator       string                   `json:"generator,omitempty"`
+	Categories      []string                 `json:"categories,omitempty"`
+	DublinCoreExt   *ext.DublinCoreExtension `json:"dcExt,omitempty"`
+	ITunesExt       *ext.ITunesFeedExtension `json:"itunesExt,omitempty"`
+	Extensions      ext.Extensions           `json:"extensions,omitempty"`
+	Custom          map[string]string        `json:"custom,omitempty"`
+	Items           []*Item                  `json:"items"`
+	FeedType        string                   `json:"feedType"`
+	FeedVersion     string                   `json:"feedVersion"`
 }
 
 func (f Feed) String() string {
@@ -41,21 +43,23 @@ func (f Feed) String() string {
 // and rss.Item gets translated to.  It represents
 // a single entry in a given feed.
 type Item struct {
-	Title           string            `json:"title,omitempty"`
-	Description     string            `json:"description,omitempty"`
-	Content         string            `json:"content,omitempty"`
-	Link            string            `json:"link,omitempty"`
-	Updated         string            `json:"updated,omitempty"`
-	UpdatedParsed   *time.Time        `json:"updatedParsed,omitempty"`
-	Published       string            `json:"published,omitempty"`
-	PublishedParsed *time.Time        `json:"publishedParsed,omitempty"`
-	Author          *Person           `json:"author,omitempty"`
-	GUID            string            `json:"guid,omitempty"`
-	Image           *Image            `json:"image,omitempty"`
-	Categories      []string          `json:"categories,omitempty"`
-	Enclosures      []*Enclosure      `json:"enclosures,omitempty"`
-	Extensions      ext.Extensions    `json:"extensions,omitempty"`
-	Custom          map[string]string `json:"custom,omitempty"`
+	Title           string                   `json:"title,omitempty"`
+	Description     string                   `json:"description,omitempty"`
+	Content         string                   `json:"content,omitempty"`
+	Link            string                   `json:"link,omitempty"`
+	Updated         string                   `json:"updated,omitempty"`
+	UpdatedParsed   *time.Time               `json:"updatedParsed,omitempty"`
+	Published       string                   `json:"published,omitempty"`
+	PublishedParsed *time.Time               `json:"publishedParsed,omitempty"`
+	Author          *Person                  `json:"author,omitempty"`
+	GUID            string                   `json:"guid,omitempty"`
+	Image           *Image                   `json:"image,omitempty"`
+	Categories      []string                 `json:"categories,omitempty"`
+	Enclosures      []*Enclosure             `json:"enclosures,omitempty"`
+	DublinCoreExt   *ext.DublinCoreExtension `json:"dcExt,omitempty"`
+	ITunesExt       *ext.ITunesItemExtension `json:"itunesExt,omitempty"`
+	Extensions      ext.Extensions           `json:"extensions,omitempty"`
+	Custom          map[string]string        `json:"custom,omitempty"`
 }
 
 // Person is an individual specified in a feed

--- a/internal/shared/extparser.go
+++ b/internal/shared/extparser.go
@@ -80,9 +80,11 @@ func parseExtensionElement(p *xpp.XMLPullParser) (e ext.Extension, err error) {
 
 			e.Children[child.Name] = append(e.Children[child.Name], child)
 		} else if tok == xpp.Text {
-			e.Value = strings.TrimSpace(p.Text)
+			e.Value += p.Text
 		}
 	}
+
+	e.Value = strings.TrimSpace(e.Value)
 
 	if err = p.Expect(xpp.EndTag, e.Name); err != nil {
 		return e, err

--- a/testdata/extensions/itunes/itunes_item_summary_cdata_multi.json
+++ b/testdata/extensions/itunes/itunes_item_summary_cdata_multi.json
@@ -1,0 +1,23 @@
+{
+    "items": [
+        {
+            "itunesExt": {
+                "summary": "Line 1\n            Line 2\n            Line 3"
+            },
+            "extensions": {
+                "itunes": {
+                    "summary": [
+                        {
+                            "name": "summary",
+                            "value": "Line 1\n            Line 2\n            Line 3",
+                            "attrs": {},
+                            "children": {}
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "feedType": "rss",
+    "feedVersion": "2.0"
+}

--- a/testdata/extensions/itunes/itunes_item_summary_cdata_multi.xml
+++ b/testdata/extensions/itunes/itunes_item_summary_cdata_multi.xml
@@ -1,0 +1,16 @@
+<!--
+Description: rss item itunes summary - cdata multiline 
+-->
+<rss version="2.0">
+  <channel>
+    <item>
+      <itunes:summary>
+          <![CDATA[
+            Line 1
+            Line 2
+            Line 3
+          ]]>
+        </itunes:summary>
+    </item>
+  </channel>
+</rss>

--- a/translator.go
+++ b/translator.go
@@ -49,6 +49,8 @@ func (t *DefaultRSSTranslator) Translate(feed interface{}) (*Feed, error) {
 	result.Generator = t.translateFeedGenerator(rss)
 	result.Categories = t.translateFeedCategories(rss)
 	result.Items = t.translateFeedItems(rss)
+	result.ITunesExt = rss.ITunesExt
+	result.DublinCoreExt = rss.DublinCoreExt
 	result.Extensions = rss.Extensions
 	result.FeedVersion = rss.Version
 	result.FeedType = "rss"
@@ -67,6 +69,8 @@ func (t *DefaultRSSTranslator) translateFeedItem(rssItem *rss.Item) (item *Item)
 	item.Image = t.translateItemImage(rssItem)
 	item.Categories = t.translateItemCategories(rssItem)
 	item.Enclosures = t.translateItemEnclosures(rssItem)
+	item.DublinCoreExt = rssItem.DublinCoreExt
+	item.ITunesExt = rssItem.ITunesExt
 	item.Extensions = rssItem.Extensions
 	return
 }


### PR DESCRIPTION
This addresses the issue of parsing extensions with consecutive text nodes.

I also took this opportunity to add the "ITunesExt" and "DublinCoreExt" fields to `gofeed.Feed` and modified the `gofeed.Translator` to pass these values up.

