### PR TITLE
Adds support for publish date in Dublin Core.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Description | /rss/channel/item/description<br>/rdf:RDF/item/description<br>/rss
 Content | | /feed/entry/content
 Link | /rss/channel/item/link<br>/rdf:RDF/item/link | /feed/entry/link[@rel=”alternate”]/@href<br>/feed/entry/link[not(@rel)]/@href
 Updated | /rss/channel/item/dc:date<br>/rdf:RDF/rdf:item/dc:date | /feed/entry/modified<br>/feed/entry/updated
-Published | /rss/channel/item/pubDate | /feed/entry/published<br>/feed/entry/issued
+Published | /rss/channel/item/pubDate<br>/rss/channel/item/dc:date | /feed/entry/published<br>/feed/entry/issued
 Author | /rss/channel/item/author<br>/rss/channel/item/dc:author<br>/rdf:RDF/item/dc:author<br>/rss/channel/item/dc:creator<br>/rdf:RDF/item/dc:creator<br>/rss/channel/item/itunes:author | /feed/entry/author
 Guid |  /rss/channel/item/guid | /feed/entry/id
 Image | /rss/channel/item/itunes:image<br>/rss/channel/item/media:image |

--- a/translator.go
+++ b/translator.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	ext "github.com/michaelrbond/gofeed/extensions"
 	"github.com/mmcdole/gofeed/atom"
+	ext "github.com/mmcdole/gofeed/extensions"
 	"github.com/mmcdole/gofeed/internal/shared"
 	"github.com/mmcdole/gofeed/rss"
 )

--- a/translator.go
+++ b/translator.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/mmcdole/gofeed/atom"
-	"github.com/mmcdole/gofeed/extensions"
 	"github.com/mmcdole/gofeed/internal/shared"
 	"github.com/mmcdole/gofeed/rss"
 )
@@ -292,12 +291,26 @@ func (t *DefaultRSSTranslator) translateItemUpdatedParsed(rssItem *rss.Item) (up
 	return
 }
 
-func (t *DefaultRSSTranslator) translateItemPublished(rssItem *rss.Item) (updated string) {
-	return rssItem.PubDate
+func (t *DefaultRSSTranslator) translateItemPublished(rssItem *rss.Item) (pubDate string) {
+	if rssItem.PubDate != "" {
+		return rssItem.PubDate
+	} else if rssItem.DublinCoreExt != nil && rssItem.DublinCoreExt.Date != nil {
+		return t.firstEntry(rssItem.DublinCoreExt.Date)
+	}
+	return
 }
 
-func (t *DefaultRSSTranslator) translateItemPublishedParsed(rssItem *rss.Item) (updated *time.Time) {
-	return rssItem.PubDateParsed
+func (t *DefaultRSSTranslator) translateItemPublishedParsed(rssItem *rss.Item) (pubDate *time.Time) {
+	if rssItem.PubDateParsed != nil {
+		return rssItem.PubDateParsed
+	} else if rssItem.DublinCoreExt != nil && rssItem.DublinCoreExt.Date != nil {
+		pubDateText := t.firstEntry(rssItem.DublinCoreExt.Date)
+		pubDateParsed, err := shared.ParseDate(pubDateText)
+		if err == nil {
+			pubDate = &pubDateParsed
+		}
+	}
+	return
 }
 
 func (t *DefaultRSSTranslator) translateItemAuthor(rssItem *rss.Item) (author *Person) {

--- a/translator.go
+++ b/translator.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/mmcdole/gofeed/atom"
-	ext "github.com/mmcdole/gofeed/extensions"
+	"github.com/mmcdole/gofeed/extensions"
 	"github.com/mmcdole/gofeed/internal/shared"
 	"github.com/mmcdole/gofeed/rss"
 )

--- a/translator.go
+++ b/translator.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	ext "github.com/michaelrbond/gofeed/extensions"
 	"github.com/mmcdole/gofeed/atom"
 	"github.com/mmcdole/gofeed/internal/shared"
 	"github.com/mmcdole/gofeed/rss"


### PR DESCRIPTION
Discovered this flaw when using Slashdot's RSS feed as an example during development. The only Published date is a DC extension.

Example RSS URL: http://rss.slashdot.org/Slashdot/slashdotMain