### PR TITLE
Add support for content:encoded

### DIFF
--- a/internal/shared/extparser.go
+++ b/internal/shared/extparser.go
@@ -13,7 +13,7 @@ import (
 func IsExtension(p *xpp.XMLPullParser) bool {
 	space := strings.TrimSpace(p.Space)
 	if prefix, ok := p.Spaces[space]; ok {
-		return !(prefix == "" || prefix == "rss" || prefix == "rdf")
+		return !(prefix == "" || prefix == "rss" || prefix == "rdf" || prefix == "content")
 	}
 
 	return p.Space != ""

--- a/rss/feed.go
+++ b/rss/feed.go
@@ -47,6 +47,7 @@ type Item struct {
 	Title         string                   `json:"title,omitempty"`
 	Link          string                   `json:"link,omitempty"`
 	Description   string                   `json:"description,omitempty"`
+	Content       string                   `json:"content,omitempty"`
 	Author        string                   `json:"author,omitempty"`
 	Categories    []*Category              `json:"categories,omitempty"`
 	Comments      string                   `json:"comments,omitempty"`

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -308,6 +308,7 @@ func (rp *Parser) parseChannel(p *xpp.XMLPullParser) (rss *Feed, err error) {
 }
 
 func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
+	var isContent bool
 
 	if err = p.Expect(xpp.StartTag, "item"); err != nil {
 		return nil, err
@@ -331,6 +332,11 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 
 			name := strings.ToLower(p.Name)
 
+			space := strings.TrimSpace(p.Space)
+			if prefix, ok := p.Spaces[space]; ok {
+				isContent = prefix == "content"
+			}
+
 			if shared.IsExtension(p) {
 				ext, err := shared.ParseExtension(extensions, p)
 				if err != nil {
@@ -349,6 +355,12 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 					return nil, err
 				}
 				item.Description = result
+			} else if isContent && name == "encoded" {
+				result, err := shared.ParseText(p)
+				if err != nil {
+					return nil, err
+				}
+				item.Content = result
 			} else if name == "link" {
 				result, err := shared.ParseText(p)
 				if err != nil {

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -308,7 +308,6 @@ func (rp *Parser) parseChannel(p *xpp.XMLPullParser) (rss *Feed, err error) {
 }
 
 func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
-	var isContent bool
 
 	if err = p.Expect(xpp.StartTag, "item"); err != nil {
 		return nil, err
@@ -332,11 +331,6 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 
 			name := strings.ToLower(p.Name)
 
-			space := strings.TrimSpace(p.Space)
-			if prefix, ok := p.Spaces[space]; ok {
-				isContent = prefix == "content"
-			}
-
 			if shared.IsExtension(p) {
 				ext, err := shared.ParseExtension(extensions, p)
 				if err != nil {
@@ -355,12 +349,15 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 					return nil, err
 				}
 				item.Description = result
-			} else if isContent && name == "encoded" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
+			} else if name == "encoded" {
+				space := strings.TrimSpace(p.Space)
+				if prefix, ok := p.Spaces[space]; ok && prefix == "content" {
+					result, err := shared.ParseText(p)
+					if err != nil {
+						return nil, err
+					}
+					item.Content = result
 				}
-				item.Content = result
 			} else if name == "link" {
 				result, err := shared.ParseText(p)
 				if err != nil {

--- a/translator.go
+++ b/translator.go
@@ -61,6 +61,7 @@ func (t *DefaultRSSTranslator) translateFeedItem(rssItem *rss.Item) (item *Item)
 	item = &Item{}
 	item.Title = t.translateItemTitle(rssItem)
 	item.Description = t.translateItemDescription(rssItem)
+	item.Content = t.translateItemContent(rssItem)
 	item.Link = t.translateItemLink(rssItem)
 	item.Published = t.translateItemPublished(rssItem)
 	item.PublishedParsed = t.translateItemPublishedParsed(rssItem)
@@ -268,6 +269,10 @@ func (t *DefaultRSSTranslator) translateItemDescription(rssItem *rss.Item) (desc
 		desc = t.firstEntry(rssItem.DublinCoreExt.Description)
 	}
 	return
+}
+
+func (t *DefaultRSSTranslator) translateItemContent(rssItem *rss.Item) (content string) {
+	return rssItem.Content
 }
 
 func (t *DefaultRSSTranslator) translateItemLink(rssItem *rss.Item) (link string) {


### PR DESCRIPTION
When content is available in a `<content:encoded></content:encoded>` tag, parse it as the item's `Content` field.

We understand it's a highly demanded feature, and we also need it in one of our projects, so we thought we'd implement it.