### PR TITLE
get keywords from iTunes extensions

### DIFF
--- a/extensions/itunes.go
+++ b/extensions/itunes.go
@@ -71,6 +71,7 @@ func NewITunesItemExtension(extensions map[string][]Extension) *ITunesItemExtens
 	entry.Explicit = parseTextExtension("explicit", extensions)
 	entry.Subtitle = parseTextExtension("subtitle", extensions)
 	entry.Summary = parseTextExtension("summary", extensions)
+	entry.Keywords = parseTextExtension("keywords", extensions)
 	entry.Image = parseImage(extensions)
 	entry.IsClosedCaptioned = parseTextExtension("isClosedCaptioned", extensions)
 	entry.Order = parseTextExtension("order", extensions)


### PR DESCRIPTION
Looks like this was accidentally omitted. 