### PR TITLE
Set the feed type detection error in a public variable

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -12,6 +12,10 @@ import (
 	"github.com/mmcdole/gofeed/rss"
 )
 
+// ErrFeedTypeNotDetected is returned when the detection system can not figure
+// out the Feed format
+var ErrFeedTypeNotDetected = errors.New("Failed to detect feed type")
+
 // HTTPError represents an HTTP error returned by a server.
 type HTTPError struct {
 	StatusCode int
@@ -65,7 +69,8 @@ func (f *Parser) Parse(feed io.Reader) (*Feed, error) {
 	case FeedTypeRSS:
 		return f.parseRSSFeed(r)
 	}
-	return nil, errors.New("Failed to detect feed type")
+
+	return nil, ErrFeedTypeNotDetected
 }
 
 // ParseURL fetches the contents of a given url and


### PR DESCRIPTION
It will allow the applications using this library to introspect this error easily