### PR TITLE
Add a User-Agent header to ParseURL()

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -79,7 +79,7 @@ func (f *Parser) ParseURL(feedURL string) (feed *Feed, err error) {
 	client := f.httpClient()
 
 	req, _ := http.NewRequest("GET", feedURL, nil)
-	req.Header.Set("User-Agent", "GoFeed RSS Reader 1.0")
+	req.Header.Set("User-Agent", "Gofeed/1.0")
 	resp, err := client.Do(req)
 
 	if err != nil {

--- a/parser.go
+++ b/parser.go
@@ -77,7 +77,10 @@ func (f *Parser) Parse(feed io.Reader) (*Feed, error) {
 // attempts to parse the response into the universal feed type.
 func (f *Parser) ParseURL(feedURL string) (feed *Feed, err error) {
 	client := f.httpClient()
-	resp, err := client.Get(feedURL)
+
+	req, _ := http.NewRequest("GET", feedURL, nil)
+	req.Header.Set("User-Agent", "GoFeed RSS Reader 1.0")
+	resp, err := client.Do(req)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I changed the .Get() call to .Do() here for a header insertion

This is a cheap edit, but I've discovered that on GETs the User-Agent is being sent blank.  This is a problem for RSS feeds from Reddit, as Reddit will send back phony 429s  (Rate Limit) responses because the User-Agent is not "valid".   Might want to expose this further if people need to imitate a User-Agent to get around a server-side restriction.