### PR TITLE
parser.go / Bug fix

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -78,7 +78,10 @@ func (f *Parser) Parse(feed io.Reader) (*Feed, error) {
 func (f *Parser) ParseURL(feedURL string) (feed *Feed, err error) {
 	client := f.httpClient()
 
-	req, _ := http.NewRequest("GET", feedURL, nil)
+	req, err := http.NewRequest("GET", feedURL, nil)
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Set("User-Agent", "Gofeed/1.0")
 	resp, err := client.Do(req)
 


### PR DESCRIPTION
http.NewRequest error return should be check.
If there is an error during NewRequest (I've experimented it), req is nil and segfault occurs during req.Header.Set()