### PR TITLE
Better support for CDATA

### DIFF
--- a/atom/parser.go
+++ b/atom/parser.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/mmcdole/gofeed/extensions"
+	ext "github.com/mmcdole/gofeed/extensions"
 	"github.com/mmcdole/gofeed/internal/shared"
-	"github.com/mmcdole/goxpp"
+	xpp "github.com/mmcdole/goxpp"
 )
 
 var (
@@ -681,10 +681,8 @@ func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
 	lowerType := strings.ToLower(text.Type)
 	lowerMode := strings.ToLower(text.Mode)
 
-	if strings.HasPrefix(result, "<![CDATA[") &&
-		strings.HasSuffix(result, "]]>") {
-		result = strings.TrimPrefix(result, "<![CDATA[")
-		result = strings.TrimSuffix(result, "]]>")
+	if strings.Contains(result, "<![CDATA[") {
+		result = shared.StripCDATA(result)
 		if lowerType == "html" || strings.Contains(lowerType, "xhtml") {
 			result, _ = ap.base.ResolveHTML(result)
 		}

--- a/detector.go
+++ b/detector.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/mmcdole/gofeed/internal/shared"
-	"github.com/mmcdole/goxpp"
+	xpp "github.com/mmcdole/goxpp"
 )
 
 // FeedType represents one of the possible feed

--- a/internal/shared/parseutils.go
+++ b/internal/shared/parseutils.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mmcdole/goxpp"
+	xpp "github.com/mmcdole/goxpp"
 )
 
 var (
@@ -20,6 +20,9 @@ var (
 	TruncatedEntity         = errors.New("truncated entity")
 	InvalidNumericReference = errors.New("invalid numeric reference")
 )
+
+const CDATA_START = "<![CDATA["
+const CDATA_END = "]]>"
 
 // ParseText is a helper function for parsing the text
 // from the current element of the XMLPullParser.
@@ -39,14 +42,44 @@ func ParseText(p *xpp.XMLPullParser) (string, error) {
 	result := text.InnerXML
 	result = strings.TrimSpace(result)
 
-	if strings.HasPrefix(result, "<![CDATA[") &&
-		strings.HasSuffix(result, "]]>") {
-		result = strings.TrimPrefix(result, "<![CDATA[")
-		result = strings.TrimSuffix(result, "]]>")
-		return result, nil
+	if strings.Contains(result, CDATA_START) {
+		return StripCDATA(result), nil
 	}
 
 	return DecodeEntities(result)
+}
+
+// StripCDATA removes CDATA tags from the string
+// content outside of CDATA tags is passed via DecodeEntities
+func StripCDATA(str string) string {
+	buf := bytes.NewBuffer([]byte{})
+
+	curr := 0
+
+	for curr < len(str) {
+
+		start := indexAt(str, CDATA_START, curr)
+
+		if start == -1 {
+			dec, _ := DecodeEntities(str[curr:])
+			buf.Write([]byte(dec))
+			return buf.String()
+		}
+
+		end := indexAt(str, CDATA_END, start)
+
+		if end == -1 {
+			dec, _ := DecodeEntities(str[curr:])
+			buf.Write([]byte(dec))
+			return buf.String()
+		}
+
+		buf.Write([]byte(str[start+len(CDATA_START) : end]))
+
+		curr = curr + end + len(CDATA_END)
+	}
+
+	return buf.String()
 }
 
 // DecodeEntities decodes escaped XML entities
@@ -150,4 +183,12 @@ func ParseNameAddress(nameAddressText string) (name string, address string) {
 		address = result[1]
 	}
 	return
+}
+
+func indexAt(str, substr string, start int) int {
+	idx := strings.Index(str[start:], substr)
+	if idx > -1 {
+		idx += start
+	}
+	return idx
 }

--- a/internal/shared/parseutils_test.go
+++ b/internal/shared/parseutils_test.go
@@ -53,3 +53,23 @@ func TestDecodeEntitiesInvalid(t *testing.T) {
 		assert.NotNil(t, err, "%q was decoded to %q", test, res)
 	}
 }
+
+func TestStripCDATA(t *testing.T) {
+	tests := []struct {
+		str string
+		res string
+	}{
+		{"<![CDATA[ test ]]>test", " test test"},
+		{"<![CDATA[test &]]> &lt;", "test & <"},
+		{"", ""},
+		{"test", "test"},
+		{"]]>", "]]>"},
+		{"<![CDATA[", "<![CDATA["},
+		{"<![CDATA[testtest", "<![CDATA[testtest"},
+	}
+
+	for _, test := range tests {
+		res := StripCDATA(test.str)
+		assert.Equal(t, test.res, res)
+	}
+}

--- a/internal/shared/parseutils_test.go
+++ b/internal/shared/parseutils_test.go
@@ -112,6 +112,7 @@ brackets or the greater-than sign using concatenated CDATA sections.
 		// and I can't place two dashes next to each other.
 		// -->`,
 		// 		},
+		{`<![CDATA[ test ]]><!-- test -->`, ` test <!-- test -->`}, // TODO: probably wrong
 		{`An example of escaped CENDs`, `An example of escaped CENDs`},
 		{`<![CDATA[This text contains a CEND ]]]]><![CDATA[>]]>`, `This text contains a CEND ]]>`},
 		{`<![CDATA[This text contains a CEND ]]]><![CDATA[]>]]>`, `This text contains a CEND ]]>`},

--- a/internal/shared/parseutils_test.go
+++ b/internal/shared/parseutils_test.go
@@ -66,6 +66,55 @@ func TestStripCDATA(t *testing.T) {
 		{"]]>", "]]>"},
 		{"<![CDATA[", "<![CDATA["},
 		{"<![CDATA[testtest", "<![CDATA[testtest"},
+		{`<![CDATA[
+    Since this is a CDATA section
+    I can use all sorts of reserved characters
+    like > < " and &
+    or write things like
+    <foo></bar>
+    but my document is still well formed!
+]]>`, `
+    Since this is a CDATA section
+    I can use all sorts of reserved characters
+    like > < " and &
+    or write things like
+    <foo></bar>
+    but my document is still well formed!
+`},
+		{`<![CDATA[
+Within this Character Data block I can
+use double dashes as much as I want (along with <, &, ', and ")
+*and* %MyParamEntity; will be expanded to the text
+"Has been expanded" ... however, I can't use
+the CEND sequence. If I need to use CEND I must escape one of the
+brackets or the greater-than sign using concatenated CDATA sections.
+]]>`, `
+Within this Character Data block I can
+use double dashes as much as I want (along with <, &, ', and ")
+*and* %MyParamEntity; will be expanded to the text
+"Has been expanded" ... however, I can't use
+the CEND sequence. If I need to use CEND I must escape one of the
+brackets or the greater-than sign using concatenated CDATA sections.
+`},
+		// 		{`<![CDATA[ test ]]><!--
+		// Within this comment I can use ]]>
+		// and other reserved characters like <
+		// &, ', and ", but %MyParamEntity; will not be expanded
+		// (if I retrieve the text of this node it will contain
+		// %MyParamEntity; and not "Has been expanded")
+		// and I can't place two dashes next to each other.
+		// -->`, ` test <!--
+		// Within this comment I can use ]]>
+		// and other reserved characters like <
+		// &, ', and ", but %MyParamEntity; will not be expanded
+		// (if I retrieve the text of this node it will contain
+		// %MyParamEntity; and not "Has been expanded")
+		// and I can't place two dashes next to each other.
+		// -->`,
+		// 		},
+		{`An example of escaped CENDs`, `An example of escaped CENDs`},
+		{`<![CDATA[This text contains a CEND ]]]]><![CDATA[>]]>`, `This text contains a CEND ]]>`},
+		{`<![CDATA[This text contains a CEND ]]]><![CDATA[]>]]>`, `This text contains a CEND ]]>`},
 	}
 
 	for _, test := range tests {

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"strings"
 
-	"github.com/mmcdole/gofeed/extensions"
+	ext "github.com/mmcdole/gofeed/extensions"
 	"github.com/mmcdole/gofeed/internal/shared"
-	"github.com/mmcdole/goxpp"
+	xpp "github.com/mmcdole/goxpp"
 )
 
 // Parser is a RSS Parser

--- a/translator.go
+++ b/translator.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/mmcdole/gofeed/atom"
-	"github.com/mmcdole/gofeed/extensions"
+	ext "github.com/mmcdole/gofeed/extensions"
 	"github.com/mmcdole/gofeed/internal/shared"
 	"github.com/mmcdole/gofeed/rss"
 )


### PR DESCRIPTION
- adds a share function to strip CDATA tags with decoding of entities outside of the tags
- adds a basic test

Open questions:
- not sure if it's a standard way to parse CDATA. Any ideas?
- anything else that this affects?