### PR TITLE
Support marshal to xml for atom

### DIFF
--- a/atom/feed.go
+++ b/atom/feed.go
@@ -2,6 +2,7 @@ package atom
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"time"
 
 	"github.com/mmcdole/gofeed/extensions"
@@ -9,23 +10,24 @@ import (
 
 // Feed is an Atom Feed
 type Feed struct {
-	Title         string         `json:"title,omitempty"`
-	ID            string         `json:"id,omitempty"`
-	Updated       string         `json:"updated,omitempty"`
-	UpdatedParsed *time.Time     `json:"updatedParsed,omitempty"`
-	Subtitle      string         `json:"subtitle,omitempty"`
-	Links         []*Link        `json:"links,omitempty"`
-	Language      string         `json:"language,omitempty"`
-	Generator     *Generator     `json:"generator,omitempty"`
-	Icon          string         `json:"icon,omitempty"`
-	Logo          string         `json:"logo,omitempty"`
-	Rights        string         `json:"rights,omitempty"`
-	Contributors  []*Person      `json:"contributors,omitempty"`
-	Authors       []*Person      `json:"authors,omitempty"`
-	Categories    []*Category    `json:"categories,omitempty"`
-	Entries       []*Entry       `json:"entries"`
-	Extensions    ext.Extensions `json:"extensions,omitempty"`
-	Version       string         `json:"version"`
+	XMLName       xml.Name       `json:"-" xml:"http://www.w3.org/2005/Atom feed"`
+	Title         string         `json:"title,omitempty" xml:"title,omitempty"`
+	ID            string         `json:"id,omitempty" xml:"id,omitempty"`
+	Updated       string         `json:"updated,omitempty" xml:"updated,omitempty"`
+	UpdatedParsed *time.Time     `json:"updatedParsed,omitempty" xml:"-"`
+	Subtitle      string         `json:"subtitle,omitempty" xml:"subtitle,omitempty"`
+	Links         []*Link        `json:"links,omitempty" xml:"link"`
+	Language      string         `json:"language,omitempty" xml:"-"`
+	Generator     *Generator     `json:"generator,omitempty" xml:"generator,omitempty"`
+	Icon          string         `json:"icon,omitempty" xml:"icon,omitempty"`
+	Logo          string         `json:"logo,omitempty" xml:"logo,omitempty"`
+	Rights        string         `json:"rights,omitempty" xml:"rights,omitempty"`
+	Contributors  []*Person      `json:"contributors,omitempty" xml:"contributor"`
+	Authors       []*Person      `json:"authors,omitempty" xml:"author"`
+	Categories    []*Category    `json:"categories,omitempty" xml:"category"`
+	Entries       []*Entry       `json:"entries" xml:"entry"`
+	Extensions    ext.Extensions `json:"extensions,omitempty" xml:"-"`
+	Version       string         `json:"version" xml:"-"`
 }
 
 func (f Feed) String() string {
@@ -35,80 +37,80 @@ func (f Feed) String() string {
 
 // Entry is an Atom Entry
 type Entry struct {
-	Title           string         `json:"title,omitempty"`
-	ID              string         `json:"id,omitempty"`
-	Updated         string         `json:"updated,omitempty"`
-	UpdatedParsed   *time.Time     `json:"updatedParsed,omitempty"`
-	Summary         string         `json:"summary,omitempty"`
-	Authors         []*Person      `json:"authors,omitempty"`
-	Contributors    []*Person      `json:"contributors,omitempty"`
-	Categories      []*Category    `json:"categories,omitempty"`
-	Links           []*Link        `json:"links,omitempty"`
-	Rights          string         `json:"rights,omitempty"`
-	Published       string         `json:"published,omitempty"`
-	PublishedParsed *time.Time     `json:"publishedParsed,omitempty"`
-	Source          *Source        `json:"source,omitempty"`
-	Content         *Content       `json:"content,omitempty"`
-	Extensions      ext.Extensions `json:"extensions,omitempty"`
+	Title           string         `json:"title,omitempty" xml:"title,omitempty"`
+	ID              string         `json:"id,omitempty" xml:"id,omitempty"`
+	Updated         string         `json:"updated,omitempty" xml:"updated,omitempty"`
+	UpdatedParsed   *time.Time     `json:"updatedParsed,omitempty" xml:"-"`
+	Summary         string         `json:"summary,omitempty" xml:"summary,omitempty"`
+	Authors         []*Person      `json:"authors,omitempty" xml:"author"`
+	Contributors    []*Person      `json:"contributors,omitempty" xml:"contributor"`
+	Categories      []*Category    `json:"categories,omitempty" xml:"category"`
+	Links           []*Link        `json:"links,omitempty" xml:"link"`
+	Rights          string         `json:"rights,omitempty" xml:"rights,omitempty"`
+	Published       string         `json:"published,omitempty" xml:"published,omitempty"`
+	PublishedParsed *time.Time     `json:"publishedParsed,omitempty" xml:"-"`
+	Source          *Source        `json:"source,omitempty" xml:"source,omitempty"`
+	Content         *Content       `json:"content,omitempty" xml:"content,omitempty"`
+	Extensions      ext.Extensions `json:"extensions,omitempty" xml:"-"`
 }
 
 // Category is category metadata for Feeds and Entries
 type Category struct {
-	Term   string `json:"term,omitempty"`
-	Scheme string `json:"scheme,omitempty"`
-	Label  string `json:"label,omitempty"`
+	Term   string `json:"term,omitempty" xml:"term,attr,omitempty"`
+	Scheme string `json:"scheme,omitempty" xml:"scheme,attr,omitempty"`
+	Label  string `json:"label,omitempty" xml:"label,attr,omitempty"`
 }
 
 // Person represents a person in an Atom feed
 // for things like Authors, Contributors, etc
 type Person struct {
-	Name  string `json:"name,omitempty"`
-	Email string `json:"email,omitempty"`
-	URI   string `json:"uri,omitempty"`
+	Name  string `json:"name,omitempty" xml:"name,omitempty"`
+	Email string `json:"email,omitempty" xml:"email,omitempty"`
+	URI   string `json:"uri,omitempty" xml:"uri,omitempty"`
 }
 
 // Link is an Atom link that defines a reference
 // from an entry or feed to a Web resource
 type Link struct {
-	Href     string `json:"href,omitempty"`
-	Hreflang string `json:"hreflang,omitempty"`
-	Rel      string `json:"rel,omitempty"`
-	Type     string `json:"type,omitempty"`
-	Title    string `json:"title,omitempty"`
-	Length   string `json:"length,omitempty"`
+	Href     string `json:"href,omitempty" xml:"href,attr,omitempty"`
+	Hreflang string `json:"hreflang,omitempty" xml:"hreflang,attr,omitempty"`
+	Rel      string `json:"rel,omitempty" xml:"rel,attr,omitempty"`
+	Type     string `json:"type,omitempty" xml:"type,attr,omitempty"`
+	Title    string `json:"title,omitempty" xml:"title,attr,omitempty"`
+	Length   string `json:"length,omitempty" xml:"length,attr,omitempty"`
 }
 
 // Content either contains or links to the content of
 // the entry
 type Content struct {
-	Src   string `json:"src,omitempty"`
-	Type  string `json:"type,omitempty"`
-	Value string `json:"value,omitempty"`
+	Src   string `json:"src,omitempty" xml:"src,attr,omitempty"`
+	Type  string `json:"type,omitempty" xml:"type,attr,omitempty"`
+	Value string `json:"value,omitempty" xml:",chardata"`
 }
 
 // Generator identifies the agent used to generate a
 // feed, for debugging and other purposes.
 type Generator struct {
-	Value   string `json:"value,omitempty"`
-	URI     string `json:"uri,omitempty"`
-	Version string `json:"version,omitempty"`
+	Value   string `json:"value,omitempty" xml:",chardata"`
+	URI     string `json:"uri,omitempty" xml:"uri,attr,omitempty"`
+	Version string `json:"version,omitempty" xml:"version,attr,omitempty"`
 }
 
 // Source contains the feed information for another
 // feed if a given entry came from that feed.
 type Source struct {
-	Title         string         `json:"title,omitempty"`
-	ID            string         `json:"id,omitempty"`
-	Updated       string         `json:"updated,omitempty"`
-	UpdatedParsed *time.Time     `json:"updatedParsed,omitempty"`
-	Subtitle      string         `json:"subtitle,omitempty"`
-	Links         []*Link        `json:"links,omitempty"`
-	Generator     *Generator     `json:"generator,omitempty"`
-	Icon          string         `json:"icon,omitempty"`
-	Logo          string         `json:"logo,omitempty"`
-	Rights        string         `json:"rights,omitempty"`
-	Contributors  []*Person      `json:"contributors,omitempty"`
-	Authors       []*Person      `json:"authors,omitempty"`
-	Categories    []*Category    `json:"categories,omitempty"`
-	Extensions    ext.Extensions `json:"extensions,omitempty"`
+	Title         string         `json:"title,omitempty" xml:"title,omitempty"`
+	ID            string         `json:"id,omitempty" xml:"id,omitempty"`
+	Updated       string         `json:"updated,omitempty" xml:"updated,omitempty"`
+	UpdatedParsed *time.Time     `json:"updatedParsed,omitempty" xml:"-"`
+	Subtitle      string         `json:"subtitle,omitempty" xml:"subtitle,omitempty"`
+	Links         []*Link        `json:"links,omitempty" xml:"link"`
+	Generator     *Generator     `json:"generator,omitempty" xml:"generator,omitempty"`
+	Icon          string         `json:"icon,omitempty" xml:"icon,omitempty"`
+	Logo          string         `json:"logo,omitempty" xml:"logo,omitempty"`
+	Rights        string         `json:"rights,omitempty" xml:"rights,omitempty"`
+	Contributors  []*Person      `json:"contributors,omitempty" xml:"contributor"`
+	Authors       []*Person      `json:"authors,omitempty" xml:"author"`
+	Categories    []*Category    `json:"categories,omitempty" xml:"category"`
+	Extensions    ext.Extensions `json:"extensions,omitempty" xml:"-"`
 }

--- a/atom/parser_test.go
+++ b/atom/parser_test.go
@@ -3,6 +3,7 @@ package atom_test
 import (
 	"bytes"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -45,6 +46,23 @@ func TestParser_Parse(t *testing.T) {
 			fmt.Printf("Failed\n")
 		}
 	}
+}
+
+func TestFeed_ToXML(t *testing.T) {
+	f, _ := ioutil.ReadFile("../testdata/parser/atom/atom10_feed_with_entry.xml")
+	fp := atom.Parser{}
+	feed, err := fp.Parse(bytes.NewReader(f))
+	assert.NotNil(t, feed)
+	assert.Nil(t, err)
+
+	b, err := xml.MarshalIndent(feed, "", "    ")
+	assert.Nil(t, err)
+
+	// Verify that we can write out the same fields that we read in
+	// assuming that it was in the same order and formatting
+	gotXml := string(b)
+	wantXml := string(f)
+	assert.Equal(t, wantXml, gotXml, "Feed xml did not match expected output atom10_feed_with_entry.xml")
 }
 
 // TODO: Examples

--- a/testdata/parser/atom/atom10_feed_with_entry.xml
+++ b/testdata/parser/atom/atom10_feed_with_entry.xml
@@ -1,0 +1,56 @@
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>Example Feed</title>
+    <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+    <subtitle>my example feed of doom</subtitle>
+    <link href="http://example.org/" rel="self"></link>
+    <generator uri="https://github.com/mmcdole/gofeed">gofeed</generator>
+    <icon>http://example.org/favicon.ico</icon>
+    <logo>http://example.org/logo.png</logo>
+    <rights>copyright 2019</rights>
+    <contributor>
+        <name>Su Li</name>
+    </contributor>
+    <author>
+        <name>John Doe</name>
+    </author>
+    <category term="robots" scheme="http://example.org/robots" label="Robots"></category>
+    <category term="scifi" scheme="http://example.org/scifi" label="Science Fiction"></category>
+    <entry>
+        <title>Atom-Powered Robots Run Amok</title>
+        <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+        <updated>2003-12-13T18:30:02Z</updated>
+        <summary>Some text.</summary>
+        <author>
+            <name>John Doe</name>
+        </author>
+        <contributor>
+            <name>Su Li</name>
+        </contributor>
+        <category term="robots" scheme="http://example.org/robots" label="Robots"></category>
+        <category term="scifi" scheme="http://example.org/scifi" label="Science Fiction"></category>
+        <link href="http://example.org/2003/12/13/atom03" rel="self"></link>
+        <rights>copyright 2019</rights>
+        <published>2003-12-13T18:30:02Z</published>
+        <source>
+            <title>Science Fiction NOW</title>
+            <id>urn:uuid:ed80826e-61ef-11e9-8647-d663bd873d93</id>
+            <updated>2000-01-01T12:12:00Z</updated>
+            <subtitle>living with science</subtitle>
+            <link href="http://example.org/" rel="self"></link>
+            <generator uri="https://github.com/mmcdole/gofeed">gofeed</generator>
+            <icon>http://example.org/favicon.ico</icon>
+            <logo>http://example.org/logo.png</logo>
+            <rights>copyright 2019</rights>
+            <contributor>
+                <name>Su Li</name>
+            </contributor>
+            <author>
+                <name>John Doe</name>
+            </author>
+            <category term="robots" scheme="http://example.org/robots" label="Robots"></category>
+            <category term="scifi" scheme="http://example.org/scifi" label="Science Fiction"></category>
+        </source>
+        <content type="text/html">&lt;p&gt;pew pew robots!&lt;/p&gt;</content>
+    </entry>
+</feed>


### PR DESCRIPTION
This adds the necessary tags to the atom structs so that someone can call xml.Marshal on an atom feed to generate the appropriate xml.

Note that Go doesn't support self-closing tags, which is why you see that the link tag in the testdata is using an empty tag instead.

I am not marshaling some fields that are calculated by the parser:Updated/PublishedParsed, Extensions, and Version. xml:lang on the root feed node isn't being marhalled either because it doesn't fit well with how the data is being represented. This seems like a good first step towards unobtrusively adding marshalling without impacting the core of gofeed.