### PR TITLE
Context support is added for ParseURL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ _testmain.go
 .DS_STORE
 
 cmd/ftest/ftest
+
+# Goland specific files
+.idea

--- a/parser.go
+++ b/parser.go
@@ -2,6 +2,7 @@ package gofeed
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -76,12 +77,20 @@ func (f *Parser) Parse(feed io.Reader) (*Feed, error) {
 // ParseURL fetches the contents of a given url and
 // attempts to parse the response into the universal feed type.
 func (f *Parser) ParseURL(feedURL string) (feed *Feed, err error) {
+	return f.ParseURLWithContext(feedURL, context.Background())
+}
+
+// ParseURLWithContext fetches contents of a given url and
+// attempts to parse the response into the universal feed type.
+// Request could be canceled or timeout via given context
+func (f *Parser) ParseURLWithContext(feedURL string, ctx context.Context) (feed *Feed, err error) {
 	client := f.httpClient()
 
 	req, err := http.NewRequest("GET", feedURL, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 	req.Header.Set("User-Agent", "Gofeed/1.0")
 	resp, err := client.Do(req)
 


### PR DESCRIPTION
`ParseURLWithContext` method is added to support cancel or timing out for http requests.