### PR TITLE
Some better support for "broken" xml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mmcdole/gofeed
+module github.com/godexsoft/gofeed
 
 require (
 	github.com/PuerkitoBio/goquery v1.5.0

--- a/internal/shared/parseutils_test.go
+++ b/internal/shared/parseutils_test.go
@@ -13,6 +13,8 @@ func TestDecodeEntities(t *testing.T) {
 	}{
 		{"", ""},
 		{"foo", "foo"},
+		{"skip & normal & amps", "skip & normal & amps"},
+		{"not & entity;hello &ne xt;one", "not & entity;hello &ne xt;one"},
 
 		{"&lt;foo&gt;", "<foo>"},
 		{"a &quot;b&quot; &apos;c&apos;", "a \"b\" 'c'"},


### PR DESCRIPTION
Currently with beta2 if the xml contains ampersands without semicolons it is considered broken (rightfully so). However, in real life, these things happen much like it does with HTML websites.
One of the feeds we had to support in our project had ampersands in titles and such (i.e. "Fish & chips"). 
Other solutions to this problem are possible: for example add a flag to skip parsing of the contents and leave that to the library user to deal with. However, i like this approach and it adds one/two more points to the "broken xml handling".