### PR TITLE
Fix: get gofeed.FeedLink from atom:link tag

### DIFF
--- a/testdata/translator/rss/feed_link_-_rss_channel_atom_link.json
+++ b/testdata/translator/rss/feed_link_-_rss_channel_atom_link.json
@@ -1,0 +1,22 @@
+{  
+  "items": [],
+  "feedType": "rss",
+  "feedVersion": "2.0",
+  "feedLink": "http://example.org",
+  "extensions": {
+        "atom": {
+            "link": [
+                {
+                    "name": "link",
+                    "value": "",
+                    "attrs": {
+                        "href": "http://example.org",
+                        "rel": "self",
+                        "type": "application/rss+xml"
+                    },
+                    "children": {}
+                }
+            ]
+        }
+    }
+}

--- a/testdata/translator/rss/feed_link_-_rss_channel_atom_link.xml
+++ b/testdata/translator/rss/feed_link_-_rss_channel_atom_link.xml
@@ -1,0 +1,8 @@
+<!--
+Description: atom link
+-->
+<rss version="2.0">
+  <channel>    
+    <atom:link href="http://example.org" rel="self" type="application/rss+xml"/>
+  </channel>
+</rss>

--- a/translator.go
+++ b/translator.go
@@ -103,8 +103,8 @@ func (t *DefaultRSSTranslator) translateFeedFeedLink(rss *rss.Feed) (link string
 	for _, ex := range atomExtensions {
 		if links, ok := ex["link"]; ok {
 			for _, l := range links {
-				if l.Attrs["Rel"] == "self" {
-					link = l.Value
+				if l.Attrs["rel"] == "self" {
+					link = l.Attrs["href"]
 				}
 			}
 		}


### PR DESCRIPTION
For the DefaultRSSTranslator the FeedLink field should get its value from the /rss/channel/atom:link[@rel="self"]/@href tag.

