### PR TITLE
Case insensitive entity matching

### DIFF
--- a/internal/shared/parseutils.go
+++ b/internal/shared/parseutils.go
@@ -142,16 +142,16 @@ func DecodeEntities(str string) (string, error) {
 				name := string(data[1:end])
 
 				var c byte
-				switch name {
-				case "lt":
+				switch {
+				case strings.EqualFold("lt", name):
 					c = '<'
-				case "gt":
+				case strings.EqualFold("gt", name):
 					c = '>'
-				case "quot":
+				case strings.EqualFold("quot", name):
 					c = '"'
-				case "apos":
+				case strings.EqualFold("apos", name):
 					c = '\''
-				case "amp":
+				case strings.EqualFold("amp", name):
 					c = '&'
 				default:
 					return "", fmt.Errorf("unknown predefined "+

--- a/internal/shared/parseutils_test.go
+++ b/internal/shared/parseutils_test.go
@@ -40,6 +40,9 @@ func TestDecodeEntities(t *testing.T) {
 
 func TestDecodeEntitiesInvalid(t *testing.T) {
 	tests := []string{
+		// Predefined entities
+		"&foo;", // unknown
+
 		// Numerical character references
 		"&#;",     // missing number
 		"&#x;",    // missing hexadecimal number

--- a/internal/shared/parseutils_test.go
+++ b/internal/shared/parseutils_test.go
@@ -23,6 +23,10 @@ func TestDecodeEntities(t *testing.T) {
 		{"&#34;foo&#34;", "\"foo\""},
 		{"&#x61;&#x062;&#x0063;", "abc"},
 		{"r&#xe9;sum&#x00E9;", "résumé"},
+		{"&", "&"},
+		{"&foo", "&foo"},
+		{"&lt", "&lt"},
+		{"&#", "&#"},
 	}
 
 	for _, test := range tests {
@@ -36,14 +40,7 @@ func TestDecodeEntities(t *testing.T) {
 
 func TestDecodeEntitiesInvalid(t *testing.T) {
 	tests := []string{
-		// Predefined entities
-		"&",     // truncated
-		"&foo",  // truncated
-		"&foo;", // unknown
-		"&lt",   // known but truncated
-
 		// Numerical character references
-		"&#",      // truncated
 		"&#;",     // missing number
 		"&#x;",    // missing hexadecimal number
 		"&#12a;",  // invalid decimal number

--- a/internal/shared/parseutils_test.go
+++ b/internal/shared/parseutils_test.go
@@ -13,6 +13,8 @@ func TestDecodeEntities(t *testing.T) {
 	}{
 		{"", ""},
 		{"foo", "foo"},
+		{"skip & normal & amps", "skip & normal & amps"},
+		{"not & entity;hello &ne xt;one", "not & entity;hello &ne xt;one"},
 
 		{"&lt;foo&gt;", "<foo>"},
 		{"a &quot;b&quot; &apos;c&apos;", "a \"b\" 'c'"},


### PR DESCRIPTION
Technically incorrect but allows for more permissive matching and should incorrectly mach entities in practice.