### PR TITLE
Force published field

### DIFF
--- a/testdata/translator/atom/feed_item_updated_-_atom03_feed_entry_modified.json
+++ b/testdata/translator/atom/feed_item_updated_-_atom03_feed_entry_modified.json
@@ -2,7 +2,9 @@
     "items": [
         {
             "updated": "Thu, 01 Jan 2004 19:48:21 GMT",
-            "updatedParsed": "2004-01-01T19:48:21Z"
+            "updatedParsed": "2004-01-01T19:48:21Z",
+            "published": "Thu, 01 Jan 2004 19:48:21 GMT",
+            "publishedParsed": "2004-01-01T19:48:21Z"
         }
     ],
     "feedType": "atom",

--- a/translator.go
+++ b/translator.go
@@ -607,18 +607,18 @@ func (t *DefaultAtomTranslator) translateItemUpdatedParsed(entry *atom.Entry) (u
 	return entry.UpdatedParsed
 }
 
-func (t *DefaultAtomTranslator) translateItemPublished(entry *atom.Entry) (updated string) {
-	updated = entry.Published
-	if updated == "" {
-		updated = entry.Updated
+func (t *DefaultAtomTranslator) translateItemPublished(entry *atom.Entry) (published string) {
+	published = entry.Published
+	if published == "" {
+		published = entry.Updated
 	}
 	return
 }
 
-func (t *DefaultAtomTranslator) translateItemPublishedParsed(entry *atom.Entry) (updated *time.Time) {
-	updated = entry.PublishedParsed
-	if updated == nil {
-		updated = entry.UpdatedParsed
+func (t *DefaultAtomTranslator) translateItemPublishedParsed(entry *atom.Entry) (published *time.Time) {
+	published = entry.PublishedParsed
+	if published == nil {
+		published = entry.UpdatedParsed
 	}
 	return
 }

--- a/translator.go
+++ b/translator.go
@@ -608,11 +608,19 @@ func (t *DefaultAtomTranslator) translateItemUpdatedParsed(entry *atom.Entry) (u
 }
 
 func (t *DefaultAtomTranslator) translateItemPublished(entry *atom.Entry) (updated string) {
-	return entry.Published
+	updated = entry.Published
+	if updated == "" {
+		updated = entry.Updated
+	}
+	return
 }
 
 func (t *DefaultAtomTranslator) translateItemPublishedParsed(entry *atom.Entry) (updated *time.Time) {
-	return entry.PublishedParsed
+	updated = entry.PublishedParsed
+	if updated == nil {
+		updated = entry.UpdatedParsed
+	}
+	return
 }
 
 func (t *DefaultAtomTranslator) translateItemAuthor(entry *atom.Entry) (author *Person) {


### PR DESCRIPTION
When an atom item only have updated field, use it to fill published.

- Less function is using published field, it has to always been
populated.
- Simplify code when using both RSS and Atom feeds.

This fix #146