### PR TITLE
Allow unknown html entities

### DIFF
--- a/internal/shared/parseutils.go
+++ b/internal/shared/parseutils.go
@@ -3,7 +3,7 @@ package shared
 import (
 	"bytes"
 	"errors"
-	"fmt"
+	"html"
 	"regexp"
 	"strconv"
 	"strings"
@@ -141,24 +141,21 @@ func DecodeEntities(str string) (string, error) {
 				// Predefined entity
 				name := string(data[1:end])
 
-				var c byte
 				switch name {
 				case "lt":
-					c = '<'
+					buf.WriteByte('<')
 				case "gt":
-					c = '>'
+					buf.WriteByte('>')
 				case "quot":
-					c = '"'
+					buf.WriteByte('"')
 				case "apos":
-					c = '\''
+					buf.WriteByte('\'')
 				case "amp":
-					c = '&'
+					buf.WriteByte('&')
 				default:
-					return "", fmt.Errorf("unknown predefined "+
-						"entity &%s;", name)
+					buf.WriteString(html.UnescapeString(string(data[0 : end+1])))
 				}
 
-				buf.WriteByte(c)
 			}
 		}
 

--- a/internal/shared/parseutils.go
+++ b/internal/shared/parseutils.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"html"
 	"regexp"
-	"strconv"
 	"strings"
 
 	xpp "github.com/mmcdole/goxpp"
@@ -119,44 +118,7 @@ func DecodeEntities(str string) (string, error) {
 			buf.Write(data)
 			return buf.String(), nil
 		} else {
-			if data[1] == '#' {
-				// Numerical character reference
-				var str string
-				base := 10
-
-				if len(data) > 2 && data[2] == 'x' {
-					str = string(data[3:end])
-					base = 16
-				} else {
-					str = string(data[2:end])
-				}
-
-				i, err := strconv.ParseUint(str, base, 32)
-				if err != nil {
-					return "", InvalidNumericReference
-				}
-
-				buf.WriteRune(rune(i))
-			} else {
-				// Predefined entity
-				name := string(data[1:end])
-
-				switch name {
-				case "lt":
-					buf.WriteByte('<')
-				case "gt":
-					buf.WriteByte('>')
-				case "quot":
-					buf.WriteByte('"')
-				case "apos":
-					buf.WriteByte('\'')
-				case "amp":
-					buf.WriteByte('&')
-				default:
-					buf.WriteString(html.UnescapeString(string(data[0 : end+1])))
-				}
-
-			}
+			buf.WriteString(html.UnescapeString(string(data[0 : end+1])))
 		}
 
 		// Skip the entity

--- a/internal/shared/parseutils_test.go
+++ b/internal/shared/parseutils_test.go
@@ -23,6 +23,7 @@ func TestDecodeEntities(t *testing.T) {
 		{"&#34;foo&#34;", "\"foo\""},
 		{"&#x61;&#x062;&#x0063;", "abc"},
 		{"r&#xe9;sum&#x00E9;", "résumé"},
+		{"r&eacute;sum&eacute;", "résumé"},
 		{"&", "&"},
 		{"&foo", "&foo"},
 		{"&lt", "&lt"},
@@ -40,9 +41,6 @@ func TestDecodeEntities(t *testing.T) {
 
 func TestDecodeEntitiesInvalid(t *testing.T) {
 	tests := []string{
-		// Predefined entities
-		"&foo;", // unknown
-
 		// Numerical character references
 		"&#;",     // missing number
 		"&#x;",    // missing hexadecimal number

--- a/internal/shared/parseutils_test.go
+++ b/internal/shared/parseutils_test.go
@@ -39,21 +39,6 @@ func TestDecodeEntities(t *testing.T) {
 	}
 }
 
-func TestDecodeEntitiesInvalid(t *testing.T) {
-	tests := []string{
-		// Numerical character references
-		"&#;",     // missing number
-		"&#x;",    // missing hexadecimal number
-		"&#12a;",  // invalid decimal number
-		"&#xfoo;", // invalid hexadecimal number
-	}
-
-	for _, test := range tests {
-		res, err := DecodeEntities(test)
-		assert.NotNil(t, err, "%q was decoded to %q", test, res)
-	}
-}
-
 func TestStripCDATA(t *testing.T) {
 	tests := []struct {
 		str string


### PR DESCRIPTION
I've encounter few feeds with html entities in <title> or <description> for ex.
`<title>Site d&#8217;actualit&eacute; g&eacute;n&eacute;raliste</title>`

Instead of clean UTF8:
`<title>Site d’actualité généraliste</title>`

Even if it's not a valid XML, it's quite easy to be tolerant, and not reject the feed.