### PR TITLE
Allow parsing of atom tags in RSS

### DIFF
--- a/atom/parser.go
+++ b/atom/parser.go
@@ -202,10 +202,6 @@ func (ap *Parser) parseEntry(p *xpp.XMLPullParser) (*Entry, error) {
 	}
 	entry := &Entry{}
 
-	contributors := []*Person{}
-	authors := []*Person{}
-	categories := []*Category{}
-	links := []*Link{}
 	extensions := ext.Extensions{}
 
 	for {
@@ -276,25 +272,25 @@ func (ap *Parser) parseEntry(p *xpp.XMLPullParser) (*Entry, error) {
 				if err != nil {
 					return nil, err
 				}
-				contributors = append(contributors, result)
+				entry.Contributors = append(entry.Contributors, result)
 			} else if name == "author" {
 				result, err := ap.parsePerson("author", p)
 				if err != nil {
 					return nil, err
 				}
-				authors = append(authors, result)
+				entry.Authors = append(entry.Authors, result)
 			} else if name == "category" {
 				result, err := ap.parseCategory(p)
 				if err != nil {
 					return nil, err
 				}
-				categories = append(categories, result)
+				entry.Categories = append(entry.Categories, result)
 			} else if name == "link" {
 				result, err := ap.parseLink(p)
 				if err != nil {
 					return nil, err
 				}
-				links = append(links, result)
+				entry.Links = append(entry.Links, result)
 			} else if name == "published" ||
 				name == "issued" {
 				result, err := ap.parseAtomText(p)
@@ -320,22 +316,6 @@ func (ap *Parser) parseEntry(p *xpp.XMLPullParser) (*Entry, error) {
 				}
 			}
 		}
-	}
-
-	if len(categories) > 0 {
-		entry.Categories = categories
-	}
-
-	if len(authors) > 0 {
-		entry.Authors = authors
-	}
-
-	if len(links) > 0 {
-		entry.Links = links
-	}
-
-	if len(contributors) > 0 {
-		entry.Contributors = contributors
 	}
 
 	if len(extensions) > 0 {

--- a/cmd/ftest/main.go
+++ b/cmd/ftest/main.go
@@ -44,7 +44,7 @@ func main() {
 		if strings.EqualFold(feedType, "rss") ||
 			strings.EqualFold(feedType, "r") {
 			p := rss.Parser{}
-			feed, err = p.Parse(strings.NewReader(fc))
+			feed, err = p.Parse(strings.NewReader(fc), gofeed.NewParser().BuildRSSExtParsers())
 		} else if strings.EqualFold(feedType, "atom") ||
 			strings.EqualFold(feedType, "a") {
 			p := atom.Parser{}

--- a/extensions/extensions.go
+++ b/extensions/extensions.go
@@ -12,6 +12,7 @@ type Extension struct {
 	Value    string                 `json:"value"`
 	Attrs    map[string]string      `json:"attrs"`
 	Children map[string][]Extension `json:"children"`
+	Parsed   interface{}            `json:"parsed,omitempty"`
 }
 
 func parseTextExtension(name string, extensions map[string][]Extension) (value string) {

--- a/extensions/extensions.go
+++ b/extensions/extensions.go
@@ -15,6 +15,10 @@ type Extension struct {
 	Parsed   interface{}            `json:"parsed,omitempty"`
 }
 
+type Extendable interface {
+	GetExtensions() Extensions
+}
+
 func parseTextExtension(name string, extensions map[string][]Extension) (value string) {
 	if extensions == nil {
 		return

--- a/internal/shared/extparser.go
+++ b/internal/shared/extparser.go
@@ -121,6 +121,8 @@ func prefixForNamespace(space string, p *xpp.XMLPullParser) string {
 // These canonical prefixes override any prefixes used in the feed itself.
 var canonicalNamespaces = map[string]string{
 	"http://webns.net/mvcb/":                                         "admin",
+	"http://www.w3.org/2005/Atom":                                    "atom",
+	"http://purl.org/atom/ns#":                                       "atom03",
 	"http://purl.org/rss/1.0/modules/aggregation/":                   "ag",
 	"http://purl.org/rss/1.0/modules/annotate/":                      "annotate",
 	"http://media.tangent.org/rss/1.0/":                              "audio",

--- a/parser.go
+++ b/parser.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mmcdole/gofeed/atom"
 	"github.com/mmcdole/gofeed/json"
+	"github.com/mmcdole/gofeed/internal/shared"
 	"github.com/mmcdole/gofeed/rss"
 )
 
@@ -155,8 +156,19 @@ func (f *Parser) parseAtomFeed(feed io.Reader) (*Feed, error) {
 	return f.atomTrans().Translate(af)
 }
 
+func (f *Parser) BuildRSSExtParsers() shared.ExtParsers {
+	extParsers := make(shared.ExtParsers, 3)
+
+	// all possible atom variants
+	extParsers["atom"] = f.ap
+	extParsers["atom10"] = f.ap
+	extParsers["atom03"] = f.ap
+
+	return extParsers
+}
+
 func (f *Parser) parseRSSFeed(feed io.Reader) (*Feed, error) {
-	rf, err := f.rp.Parse(feed)
+	rf, err := f.rp.Parse(feed, f.BuildRSSExtParsers())
 	if err != nil {
 		return nil, err
 	}

--- a/rss/feed.go
+++ b/rss/feed.go
@@ -38,6 +38,10 @@ type Feed struct {
 	Version             string                   `json:"version"`
 }
 
+func (f Feed) GetExtensions() ext.Extensions {
+	return f.Extensions
+}
+
 func (f Feed) String() string {
 	json, _ := json.MarshalIndent(f, "", "    ")
 	return string(json)
@@ -63,6 +67,10 @@ type Item struct {
 	ITunesExt     *ext.ITunesItemExtension `json:"itunesExt,omitempty"`
 	Extensions    ext.Extensions           `json:"extensions,omitempty"`
 	Custom        map[string]string        `json:"custom,omitempty"`
+}
+
+func (i Item) GetExtensions() ext.Extensions {
+	return i.Extensions
 }
 
 // Image is an image that represents the feed

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -11,11 +11,14 @@ import (
 )
 
 // Parser is a RSS Parser
-type Parser struct{}
+type Parser struct {
+	extParsers shared.ExtParsers
+}
 
 // Parse parses an xml feed into an rss.Feed
-func (rp *Parser) Parse(feed io.Reader) (*Feed, error) {
+func (rp *Parser) Parse(feed io.Reader, extParsers shared.ExtParsers) (*Feed, error) {
 	p := xpp.NewXMLPullParser(feed, false, shared.NewReaderLabel)
+	rp.extParsers = extParsers
 
 	_, err := shared.FindRoot(p)
 	if err != nil {
@@ -141,7 +144,8 @@ func (rp *Parser) parseChannel(p *xpp.XMLPullParser) (rss *Feed, err error) {
 			name := strings.ToLower(p.Name)
 
 			if shared.IsExtension(p) {
-				ext, err := shared.ParseExtension(extensions, p)
+
+				ext, err := shared.ParseExtension(extensions, p, rp.extParsers)
 				if err != nil {
 					return nil, err
 				}
@@ -338,7 +342,7 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 			name := strings.ToLower(p.Name)
 
 			if shared.IsExtension(p) {
-				ext, err := shared.ParseExtension(extensions, p)
+				ext, err := shared.ParseExtension(extensions, p, rp.extParsers)
 				if err != nil {
 					return nil, err
 				}

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -144,8 +144,8 @@ func (rp *Parser) parseChannel(p *xpp.XMLPullParser) (rss *Feed, err error) {
 			name := strings.ToLower(p.Name)
 
 			if shared.IsExtension(p) {
-
-				ext, err := shared.ParseExtension(extensions, p, rp.extParsers)
+				// TODO: Currently no extParser support for channels
+				ext, err := shared.ParseExtension(extensions, p, make(shared.ExtParsers))
 				if err != nil {
 					return nil, err
 				}

--- a/rss/parser_test.go
+++ b/rss/parser_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mmcdole/gofeed"
 	"github.com/mmcdole/gofeed/rss"
 	"github.com/stretchr/testify/assert"
 )
@@ -27,7 +28,7 @@ func TestParser_Parse(t *testing.T) {
 
 		// Parse actual feed
 		fp := &rss.Parser{}
-		actual, _ := fp.Parse(bytes.NewReader(f))
+		actual, _ := fp.Parse(bytes.NewReader(f), gofeed.NewParser().BuildRSSExtParsers())
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("../testdata/parser/rss/%s.json", name)

--- a/rss/parser_test.go
+++ b/rss/parser_test.go
@@ -30,6 +30,15 @@ func TestParser_Parse(t *testing.T) {
 		fp := &rss.Parser{}
 		actual, _ := fp.Parse(bytes.NewReader(f), gofeed.NewParser().BuildRSSExtParsers())
 
+		// the `Parsed` part of extensions is not correctly unmarshalled from JSON
+		// workaround: move the actual extensions through a round of json marshalling so that we get the same
+		for _, i := range actual.Items {
+			if len(i.Extensions) > 0 {
+				b, _ := json.Marshal(i.Extensions)
+				json.Unmarshal(b, &i.Extensions)
+			}
+		}
+
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("../testdata/parser/rss/%s.json", name)
 		e, _ := ioutil.ReadFile(ef)

--- a/testdata/parser/rss/rss_channel_item_author_atom.json
+++ b/testdata/parser/rss/rss_channel_item_author_atom.json
@@ -1,0 +1,26 @@
+{
+    "items": [
+        {
+            "extensions": {
+                "atom": {
+                    "author": [
+                        {
+                            "name": "author",
+                            "value": "",
+                            "attrs": null,
+                            "children": null,
+                            "parsed": {
+                                "authors": [
+                                    {
+                                        "name": "Item Author"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_item_author_atom.xml
+++ b/testdata/parser/rss/rss_channel_item_author_atom.xml
@@ -1,0 +1,10 @@
+<!--
+Description: rss item with atom author
+-->
+<rss version="2.0" xmlns:a10="http://www.w3.org/2005/Atom">
+  <channel>
+    <item>
+      <a10:author><a10:name>Item Author</a10:name></a10:author>
+    </item>
+  </channel>
+</rss>

--- a/testdata/translator/rss/feed_item_author_-_rss_channel_item_author_atom.json
+++ b/testdata/translator/rss/feed_item_author_-_rss_channel_item_author_atom.json
@@ -1,0 +1,33 @@
+{
+  "items": [
+    {
+      "author": {
+        "name": "Item Author"
+      },
+      "authors": [
+          {
+              "name": "Item Author"
+          }
+      ],
+      "extensions": {
+        "atom": {
+          "author": [
+            {
+              "name": "author",
+              "value": "",
+              "parsed": {
+                "authors": [
+                  {
+                    "name": "Item Author"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "feedType": "rss",
+  "feedVersion": "2.0"
+}

--- a/testdata/translator/rss/feed_item_author_-_rss_channel_item_author_atom.xml
+++ b/testdata/translator/rss/feed_item_author_-_rss_channel_item_author_atom.xml
@@ -1,0 +1,10 @@
+<!--
+Description: rss item with atom author
+-->
+<rss version="2.0" xmlns:a10="http://www.w3.org/2005/Atom">
+  <channel>
+    <item>
+      <a10:author><a10:name>Item Author</a10:name></a10:author>
+    </item>
+  </channel>
+</rss>

--- a/testdata/translator/rss/feed_item_updated_-_rss_channel_item_updated_atom.json
+++ b/testdata/translator/rss/feed_item_updated_-_rss_channel_item_updated_atom.json
@@ -1,0 +1,24 @@
+{
+  "items": [
+    {
+      "updated": "Thu, 01 Jan 2004 19:48:21 GMT",
+      "updatedParsed": "2004-01-01T19:48:21Z",
+      "extensions": {
+        "atom": {
+          "updated": [
+            {
+              "name": "updated",
+              "value": "",
+              "parsed": {
+                "updated": "Thu, 01 Jan 2004 19:48:21 GMT",
+                "updatedParsed": "2004-01-01T19:48:21Z"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "feedType": "rss",
+  "feedVersion": "2.0"
+}

--- a/testdata/translator/rss/feed_item_updated_-_rss_channel_item_updated_atom.xml
+++ b/testdata/translator/rss/feed_item_updated_-_rss_channel_item_updated_atom.xml
@@ -1,0 +1,10 @@
+<!--
+Description: item updated (atom)
+-->
+<rss version="2.0" xmlns:a10="http://www.w3.org/2005/Atom">
+  <channel>
+    <item>
+      <a10:updated>Thu, 01 Jan 2004 19:48:21 GMT</a10:updated>
+    </item>
+  </channel>
+</rss>

--- a/translator.go
+++ b/translator.go
@@ -71,6 +71,8 @@ func (t *DefaultRSSTranslator) translateFeedItem(rssItem *rss.Item) (item *Item)
 	item.Links = t.translateItemLinks(rssItem)
 	item.Published = t.translateItemPublished(rssItem)
 	item.PublishedParsed = t.translateItemPublishedParsed(rssItem)
+	item.Updated = t.translateItemUpdated(rssItem)
+	item.UpdatedParsed = t.translateItemUpdatedParsed(rssItem)
 	item.Author = t.translateItemAuthor(rssItem)
 	item.Authors = t.translateItemAuthors(rssItem)
 	item.GUID = t.translateItemGUID(rssItem)
@@ -316,18 +318,20 @@ func (t *DefaultRSSTranslator) translateItemLinks(rssItem *rss.Item) (links []st
 }
 
 func (t *DefaultRSSTranslator) translateItemUpdated(rssItem *rss.Item) (updated string) {
-	if rssItem.DublinCoreExt != nil && rssItem.DublinCoreExt.Date != nil {
+	if updatedVal, ok := t.hasAtomExtensionsForKey(rssItem, "updated"); ok {
+		updated = t.atomTranslator.translateItemUpdated(updatedVal)
+	} else if rssItem.DublinCoreExt != nil && rssItem.DublinCoreExt.Date != nil {
 		updated = t.firstEntry(rssItem.DublinCoreExt.Date)
 	}
 	return updated
 }
 
 func (t *DefaultRSSTranslator) translateItemUpdatedParsed(rssItem *rss.Item) (updated *time.Time) {
-	if rssItem.DublinCoreExt != nil && rssItem.DublinCoreExt.Date != nil {
-		updatedText := t.firstEntry(rssItem.DublinCoreExt.Date)
+	if updatedText := t.translateItemUpdated(rssItem); updatedText != "" {
 		updatedDate, err := shared.ParseDate(updatedText)
 		if err == nil {
-			updated = &updatedDate
+			utcDate := updatedDate.UTC()
+			updated = &utcDate
 		}
 	}
 	return

--- a/translator_test.go
+++ b/translator_test.go
@@ -32,8 +32,17 @@ func TestDefaultRSSTranslator_Translate(t *testing.T) {
 		// Parse actual feed
 		translator := &gofeed.DefaultRSSTranslator{}
 		fp := &rss.Parser{}
-		rssFeed, _ := fp.Parse(f)
+		rssFeed, _ := fp.Parse(f, gofeed.NewParser().BuildRSSExtParsers())
 		actual, _ := translator.Translate(rssFeed)
+
+		// the `Parsed` part of extensions is not correctly unmarshalled from JSON
+		// workaround: move the actual extensions through a round of json marshalling so that we get the same
+		for _, i := range actual.Items {
+			if len(i.Extensions) > 0 {
+				b, _ := jsonEncoding.Marshal(i.Extensions)
+				jsonEncoding.Unmarshal(b, &i.Extensions)
+			}
+		}
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("testdata/translator/rss/%s.json", name)


### PR DESCRIPTION
As needed per #151, I added parsing of atom tags in RSS.

This adds a mechanism to add a parser for certain extension namespaces. This is now only implemented for calling Atom from RSS. This avoids re-handling Atom in RSS by calling the Atom parser directly.

The implementation tries to be very agnostic: the RSS parser knows nothing about Atom. I played with the idea of removing the abstraction and couple them tighter, but the result was not that different -- so I settled with the nicer agnostic one.

The translation phase, of course, is not agnostic anymore, because it has to know what to put where.

**Remarks**:
 - This implementation currently only supports calling the external parser on the item level. Adding parsing on channel level is trivial, the translation phase then is more involved, because currently everything expects an `*atom.Entry`.
- The initialisation of the inner atom parser might not be completely correct (see `atom/parser.go#ParseAsExtension`), because I do not know the idea behind base and the url stack.
- Due to the agnostic ways of the approach, the JSON decoder does not precisely know what to do with the extensions. Thus, for the tests, the extensions of the `actual` object take a JSON-detour (i.e., en- then decoded) to match the `expected`. 
- The translation of atom-tags is currently only added for `author` and `updated`. If more are needed, they need to be added.

Resolves #151 