### PR TITLE
Support multiple links

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/mmcdole/gofeed/extensions"
+	ext "github.com/mmcdole/gofeed/extensions"
 )
 
 // Feed is the universal Feed type that atom.Feed
@@ -17,6 +17,7 @@ type Feed struct {
 	Description     string                   `json:"description,omitempty"`
 	Link            string                   `json:"link,omitempty"`
 	FeedLink        string                   `json:"feedLink,omitempty"`
+	Links           []string                 `json:"links,omitempty"`
 	Updated         string                   `json:"updated,omitempty"`
 	UpdatedParsed   *time.Time               `json:"updatedParsed,omitempty"`
 	Published       string                   `json:"published,omitempty"`
@@ -49,6 +50,7 @@ type Item struct {
 	Description     string                   `json:"description,omitempty"`
 	Content         string                   `json:"content,omitempty"`
 	Link            string                   `json:"link,omitempty"`
+	Links           []string                 `json:"links,omitempty"`
 	Updated         string                   `json:"updated,omitempty"`
 	UpdatedParsed   *time.Time               `json:"updatedParsed,omitempty"`
 	Published       string                   `json:"published,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.14
 
 require (
 	github.com/PuerkitoBio/goquery v1.5.1
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/json-iterator/go v1.1.10
 	github.com/mmcdole/goxpp v0.0.0-20181012175147-0068e33feabf
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/urfave/cli v1.22.3 h1:FpNT6zq26xNpHZy08emi755QwzLPs6Pukqjlc7RfOMU=

--- a/testdata/parser/rss/rss_channel_item_link.json
+++ b/testdata/parser/rss/rss_channel_item_link.json
@@ -1,7 +1,10 @@
 {
     "items": [
         {
-            "link": "http://example.org"
+            "link": "http://example.org",
+            "links": [
+                "http://example.org"
+            ]
         }
     ],
     "version": "2.0"

--- a/testdata/translator/atom/feed_feedlink_-_atom10_feed_link_rel_self.json
+++ b/testdata/translator/atom/feed_feedlink_-_atom10_feed_link_rel_self.json
@@ -1,5 +1,8 @@
 {
     "feedLink": "http://example.org",
+    "links": [
+        "http://example.org"
+    ],
     "items": [],
     "feedType": "atom",
     "feedVersion": "1.0"

--- a/testdata/translator/atom/feed_item_link_-_atom03_feed_entry_link.json
+++ b/testdata/translator/atom/feed_item_link_-_atom03_feed_entry_link.json
@@ -1,7 +1,10 @@
 {
     "items": [
         {
-            "link": "http://www.example.org"
+            "link": "http://www.example.org",
+            "links": [
+                "http://www.example.org"
+            ]
         }
     ],
     "feedType": "atom",

--- a/testdata/translator/atom/feed_item_link_-_atom10_feed_entry_link.json
+++ b/testdata/translator/atom/feed_item_link_-_atom10_feed_entry_link.json
@@ -1,7 +1,10 @@
 {
     "items": [
         {
-            "link": "http://www.example.org"
+            "link": "http://www.example.org",
+            "links": [
+                "http://www.example.org"
+            ]
         }
     ],
     "feedType": "atom",

--- a/testdata/translator/atom/feed_link_-_atom03_feed_link.json
+++ b/testdata/translator/atom/feed_link_-_atom03_feed_link.json
@@ -1,5 +1,8 @@
 {
     "link": "http://www.example.org",
+    "links": [
+        "http://www.example.org"
+    ],
     "items": [],
     "feedType": "atom",
     "feedVersion": "0.3"

--- a/testdata/translator/atom/feed_link_-_atom10_feed_link.json
+++ b/testdata/translator/atom/feed_link_-_atom10_feed_link.json
@@ -1,5 +1,8 @@
 {
     "link": "http://www.example.org",
+    "links": [
+        "http://www.example.org"
+    ],
     "items": [],
     "feedType": "atom",
     "feedVersion": "1.0"

--- a/testdata/translator/rss/feed_item_link_-_rdf_item_link.json
+++ b/testdata/translator/rss/feed_item_link_-_rdf_item_link.json
@@ -1,7 +1,10 @@
 {
     "items": [
         {
-            "link": "http://example.org"
+            "link": "http://example.org",
+            "links": [
+                "http://example.org"
+            ]
         }
     ],
     "feedType": "rss",

--- a/testdata/translator/rss/feed_item_link_-_rss_channel_item_link.json
+++ b/testdata/translator/rss/feed_item_link_-_rss_channel_item_link.json
@@ -1,7 +1,10 @@
 {
     "items": [
         {
-            "link": "http://example.org"
+            "link": "http://example.org",
+            "links": [
+                "http://example.org"
+            ]
         }
     ],
     "feedType": "rss",

--- a/testdata/translator/rss/feed_link_-_rdf_channel_link.json
+++ b/testdata/translator/rss/feed_link_-_rdf_channel_link.json
@@ -1,5 +1,8 @@
 {
     "link": "http://example.org",
+    "links": [
+        "http://example.org"
+    ],
     "items": [],
     "feedType": "rss",
     "feedVersion": "1.0"

--- a/testdata/translator/rss/feed_link_-_rss_channel_atom_link.json
+++ b/testdata/translator/rss/feed_link_-_rss_channel_atom_link.json
@@ -1,9 +1,12 @@
-{  
-  "items": [],
-  "feedType": "rss",
-  "feedVersion": "2.0",
-  "feedLink": "http://example.org",
-  "extensions": {
+{
+    "items": [],
+    "feedType": "rss",
+    "feedVersion": "2.0",
+    "feedLink": "http://example.org",
+    "links": [
+        "http://example.org"
+    ],
+    "extensions": {
         "atom": {
             "link": [
                 {

--- a/testdata/translator/rss/feed_link_-_rss_channel_link.json
+++ b/testdata/translator/rss/feed_link_-_rss_channel_link.json
@@ -1,5 +1,8 @@
 {
     "link": "http://example.org",
+    "links": [
+        "http://example.org"
+    ],
     "items": [],
     "feedType": "rss",
     "feedVersion": "2.0"

--- a/translator.go
+++ b/translator.go
@@ -39,6 +39,7 @@ func (t *DefaultRSSTranslator) Translate(feed interface{}) (*Feed, error) {
 	result.Description = t.translateFeedDescription(rss)
 	result.Link = t.translateFeedLink(rss)
 	result.FeedLink = t.translateFeedFeedLink(rss)
+	result.Links = t.translateFeedLinks(rss)
 	result.Updated = t.translateFeedUpdated(rss)
 	result.UpdatedParsed = t.translateFeedUpdatedParsed(rss)
 	result.Published = t.translateFeedPublished(rss)
@@ -64,6 +65,7 @@ func (t *DefaultRSSTranslator) translateFeedItem(rssItem *rss.Item) (item *Item)
 	item.Description = t.translateItemDescription(rssItem)
 	item.Content = t.translateItemContent(rssItem)
 	item.Link = t.translateItemLink(rssItem)
+	item.Links = t.translateItemLinks(rssItem)
 	item.Published = t.translateItemPublished(rssItem)
 	item.PublishedParsed = t.translateItemPublishedParsed(rssItem)
 	item.Author = t.translateItemAuthor(rssItem)
@@ -107,6 +109,24 @@ func (t *DefaultRSSTranslator) translateFeedFeedLink(rss *rss.Feed) (link string
 				if l.Attrs["rel"] == "self" {
 					link = l.Attrs["href"]
 				}
+			}
+		}
+	}
+	return
+}
+
+func (t *DefaultRSSTranslator) translateFeedLinks(rss *rss.Feed) (links []string) {
+	if rss.Link != "" {
+		links = append(links, rss.Link)
+	}
+	if rss.ITunesExt != nil && rss.ITunesExt.Subtitle != "" {
+		links = append(links, rss.ITunesExt.Subtitle)
+	}
+	atomExtensions := t.extensionsForKeys([]string{"atom", "atom10", "atom03"}, rss.Extensions)
+	for _, ex := range atomExtensions {
+		if lks, ok := ex["link"]; ok {
+			for _, l := range lks {
+				links = append(links, l.Attrs["href"])
 			}
 		}
 	}
@@ -279,6 +299,9 @@ func (t *DefaultRSSTranslator) translateItemContent(rssItem *rss.Item) (content 
 func (t *DefaultRSSTranslator) translateItemLink(rssItem *rss.Item) (link string) {
 	return rssItem.Link
 }
+func (t *DefaultRSSTranslator) translateItemLinks(rssItem *rss.Item) (links []string) {
+	return []string{rssItem.Link}
+}
 
 func (t *DefaultRSSTranslator) translateItemUpdated(rssItem *rss.Item) (updated string) {
 	if rssItem.DublinCoreExt != nil && rssItem.DublinCoreExt.Date != nil {
@@ -449,6 +472,7 @@ func (t *DefaultAtomTranslator) Translate(feed interface{}) (*Feed, error) {
 	result.Description = t.translateFeedDescription(atom)
 	result.Link = t.translateFeedLink(atom)
 	result.FeedLink = t.translateFeedFeedLink(atom)
+	result.Links = t.translateFeedLinks(atom)
 	result.Updated = t.translateFeedUpdated(atom)
 	result.UpdatedParsed = t.translateFeedUpdatedParsed(atom)
 	result.Author = t.translateFeedAuthor(atom)
@@ -470,6 +494,7 @@ func (t *DefaultAtomTranslator) translateFeedItem(entry *atom.Entry) (item *Item
 	item.Description = t.translateItemDescription(entry)
 	item.Content = t.translateItemContent(entry)
 	item.Link = t.translateItemLink(entry)
+	item.Links = t.translateItemLinks(entry)
 	item.Updated = t.translateItemUpdated(entry)
 	item.UpdatedParsed = t.translateItemUpdatedParsed(entry)
 	item.Published = t.translateItemPublished(entry)
@@ -503,6 +528,15 @@ func (t *DefaultAtomTranslator) translateFeedFeedLink(atom *atom.Feed) (link str
 	feedLink := t.firstLinkWithType("self", atom.Links)
 	if feedLink != nil {
 		link = feedLink.Href
+	}
+	return
+}
+
+func (t *DefaultAtomTranslator) translateFeedLinks(atom *atom.Feed) (links []string) {
+	for _, l := range atom.Links {
+		if l.Rel == "" || l.Rel == "alternate" || l.Rel == "self" {
+			links = append(links, l.Href)
+		}
 	}
 	return
 }
@@ -596,6 +630,15 @@ func (t *DefaultAtomTranslator) translateItemLink(entry *atom.Entry) (link strin
 	l := t.firstLinkWithType("alternate", entry.Links)
 	if l != nil {
 		link = l.Href
+	}
+	return
+}
+
+func (t *DefaultAtomTranslator) translateItemLinks(entry *atom.Entry) (links []string) {
+	for _, l := range entry.Links {
+		if l.Rel == "" || l.Rel == "alternate" || l.Rel == "self" {
+			links = append(links, l.Href)
+		}
 	}
 	return
 }
@@ -729,6 +772,7 @@ func (t *DefaultJSONTranslator) translateFeedItem(jsonItem *json.Item) (item *It
 	item = &Item{}
 	item.GUID = t.translateItemGUID(jsonItem)
 	item.Link = t.translateItemLink(jsonItem)
+	item.Links = t.translateItemLinks(jsonItem)
 	item.Title = t.translateItemTitle(jsonItem)
 	item.Content = t.translateItemContent(jsonItem)
 	item.Description = t.translateItemDescription(jsonItem)
@@ -859,6 +903,10 @@ func (t *DefaultJSONTranslator) translateItemContent(jsonItem *json.Item) (conte
 
 func (t *DefaultJSONTranslator) translateItemLink(jsonItem *json.Item) (link string) {
 	return jsonItem.URL
+}
+
+func (t *DefaultJSONTranslator) translateItemLinks(jsonItem *json.Item) (links []string) {
+	return []string{jsonItem.URL}
 }
 
 func (t *DefaultJSONTranslator) translateItemUpdated(jsonItem *json.Item) (updated string) {

--- a/translator.go
+++ b/translator.go
@@ -300,6 +300,9 @@ func (t *DefaultRSSTranslator) translateItemLink(rssItem *rss.Item) (link string
 	return rssItem.Link
 }
 func (t *DefaultRSSTranslator) translateItemLinks(rssItem *rss.Item) (links []string) {
+	if rssItem.Link == "" {
+		return nil
+	}
 	return []string{rssItem.Link}
 }
 


### PR DESCRIPTION
This adds a `Links` var to `Feed` and `Items`. This was mainly created to allow the usage of Atom feeds with multiple links for each item, but the variable captures RSS feeds that have multiple links for a feed as well.