### PR TITLE
Ability to parse custom fields in rss that are not part of the spec

### DIFF
--- a/rss/feed.go
+++ b/rss/feed.go
@@ -59,6 +59,7 @@ type Item struct {
 	DublinCoreExt *ext.DublinCoreExtension `json:"dcExt,omitempty"`
 	ITunesExt     *ext.ITunesItemExtension `json:"itunesExt,omitempty"`
 	Extensions    ext.Extensions           `json:"extensions,omitempty"`
+	Custom        map[string]string        `json:"custom,omitempty"`
 }
 
 // Image is an image that represents the feed

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -415,8 +415,14 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 				}
 				categories = append(categories, result)
 			} else {
-				// Skip any elements not part of the item spec
-				p.Skip()
+				result, err := shared.ParseText(p)
+				if err != nil {
+					continue
+				}
+				if item.Custom == nil {
+					item.Custom = make(map[string]string, 0)
+				}
+				item.Custom[name] = result
 			}
 		}
 	}

--- a/testdata/parser/rss/rss_channel_item_custom.json
+++ b/testdata/parser/rss/rss_channel_item_custom.json
@@ -1,0 +1,11 @@
+{
+  "items": [
+    {
+      "custom": {
+        "apcategory": "s",
+        "test": "test"
+      }
+    }
+  ],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_item_custom.xml
+++ b/testdata/parser/rss/rss_channel_item_custom.xml
@@ -1,0 +1,11 @@
+<!--
+Description: rss item categories 
+-->
+<rss version="2.0">
+  <channel>
+    <item>
+      <apcategory>s</apcategory>
+      <test>test</test>
+    </item>
+  </channel>
+</rss>

--- a/testdata/translator/rss/feed_item_category_-_rss_channel_item_custom.json
+++ b/testdata/translator/rss/feed_item_category_-_rss_channel_item_custom.json
@@ -1,0 +1,12 @@
+{
+  "items": [
+    {
+      "custom": {
+        "apcategory": "s",
+        "test": "test"
+      }
+    }
+  ],
+  "feedType": "rss",
+  "feedVersion": "2.0"
+}

--- a/testdata/translator/rss/feed_item_category_-_rss_channel_item_custom.xml
+++ b/testdata/translator/rss/feed_item_category_-_rss_channel_item_custom.xml
@@ -1,0 +1,8 @@
+<rss version="2.0">
+  <channel>
+    <item>
+      <test>test</test>
+      <apcategory>s</apcategory>
+    </item>
+  </channel>
+</rss>

--- a/translator.go
+++ b/translator.go
@@ -78,6 +78,7 @@ func (t *DefaultRSSTranslator) translateFeedItem(rssItem *rss.Item) (item *Item)
 	item.DublinCoreExt = rssItem.DublinCoreExt
 	item.ITunesExt = rssItem.ITunesExt
 	item.Extensions = rssItem.Extensions
+	item.Custom = rssItem.Custom
 	return
 }
 


### PR DESCRIPTION
I have a requirement to parse elements that are not part of the standard spec.  Noticed someone also recently raised this as part of the issue #174

Raising this pull request in case this will be helpful for others.