### PR TITLE
Use `runes.Remove` instead of deprecated `transform.RemoveFunc`

### DIFF
--- a/internal/shared/xmlsanitizer.go
+++ b/internal/shared/xmlsanitizer.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"io"
 
+	"golang.org/x/text/runes"
 	"golang.org/x/text/transform"
 )
 
@@ -10,14 +11,16 @@ import (
 // wraps another io.Reader and removes illegal xml
 // characters from the io stream.
 func NewXMLSanitizerReader(xml io.Reader) io.Reader {
-	isIllegal := func(r rune) bool {
-		return !(r == 0x09 ||
-			r == 0x0A ||
-			r == 0x0D ||
-			r >= 0x20 && r <= 0xDF77 ||
-			r >= 0xE000 && r <= 0xFFFD ||
-			r >= 0x10000 && r <= 0x10FFFF)
-	}
-	t := transform.Chain(transform.RemoveFunc(isIllegal))
+	isIllegal := runes.Predicate(func() func(rune) bool {
+		return func(r rune) bool {
+			return !(r == 0x09 ||
+				r == 0x0A ||
+				r == 0x0D ||
+				r >= 0x20 && r <= 0xDF77 ||
+				r >= 0xE000 && r <= 0xFFFD ||
+				r >= 0x10000 && r <= 0x10FFFF)
+		}
+	}())
+	t := transform.Chain(runes.Remove(isIllegal))
 	return transform.NewReader(xml, t)
 }


### PR DESCRIPTION
`transform.RemoveFunc` is deprecated since https://github.com/golang/text/commit/8bf377e291b5e40c0e6bd1b8e139f4ba31e87a21
Ref: https://pkg.go.dev/golang.org/x/text/transform#RemoveFunc