### PR TITLE
Ability to provide additional HTTP request headers when parsing URL

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -104,6 +104,9 @@ func (f *Parser) ParseURL(feedURL string) (feed *Feed, err error) {
 // You can instantiate the Auth structure with your Username and Password
 // to use the BasicAuth during the HTTP call.
 // It will be automatically added to the header of the request
+// AdditionalHeaders map contains key/value pairs, representing the
+// additional headers to be added to the request. Useful for requesting
+// full content only when it's changed using ETag or If-Modified-Since.
 // Request could be canceled or timeout via given context
 func (f *Parser) ParseURLWithContext(feedURL string, ctx context.Context) (feed *Feed, err error) {
 	client := f.httpClient()

--- a/parser.go
+++ b/parser.go
@@ -106,7 +106,7 @@ func (f *Parser) ParseURL(feedURL string) (feed *Feed, err error) {
 // It will be automatically added to the header of the request
 // AdditionalHeaders map contains key/value pairs, representing the
 // additional headers to be added to the request. Useful for requesting
-// full content only when it's changed using ETag or If-Modified-Since.
+// full content only when it's changed using If-None-Match or If-Modified-Since.
 // Request could be canceled or timeout via given context
 func (f *Parser) ParseURLWithContext(feedURL string, ctx context.Context) (feed *Feed, err error) {
 	client := f.httpClient()

--- a/parser_test.go
+++ b/parser_test.go
@@ -168,6 +168,15 @@ func TestParser_ParseURL_Failure(t *testing.T) {
 	assert.Nil(t, feed)
 }
 
+func TestParser_ParseURL_WithAdditionalHeaders(t *testing.T) {
+	server, _ := mockServerResponse(304, "", 0)
+	fp := gofeed.NewParser()
+	fp.AdditionalHeaders["etag"] = "1234"
+	feed, err := fp.ParseURL(server.URL)
+	assert.Nil(t, err)
+	assert.Equal(t, feed, &gofeed.Feed{})
+}
+
 func TestParser_ParseURLWithContextAndBasicAuth(t *testing.T) {
 	server, client := mockServerResponse(404, "", 1*time.Minute)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/parser_test.go
+++ b/parser_test.go
@@ -171,7 +171,7 @@ func TestParser_ParseURL_Failure(t *testing.T) {
 func TestParser_ParseURL_WithAdditionalHeaders(t *testing.T) {
 	server, _ := mockServerResponse(304, "", 0)
 	fp := gofeed.NewParser()
-	fp.AdditionalHeaders["etag"] = "1234"
+	fp.AdditionalHeaders["If-None-Match"] = "1234"
 	feed, err := fp.ParseURL(server.URL)
 	assert.Nil(t, err)
 	assert.Equal(t, feed, &gofeed.Feed{})


### PR DESCRIPTION
Using instance map `AdditionalHeaders`, you can add headers to be sent along with the request. 

For example, this is extremely useful when you don't want to overly request the contents of the feed if it hasn't changed. The following example illustrates using `etag` header. 

```go
fp := gofeed.NewParser()
fp.AdditionalHeaders["etag"] = "1234"
feed, err := fp.ParseURL(server.URL)
```

Note, that in the case of HTTP status 304 (Not Modified), an empty `gofeed.Feed` struct is returned, since it is not modified. As a side effect, there might be some behavioral changes, since before this PR all status codes >=300 were considered as errors. This is not actually true - status codes above or equal to 400 must be considered as errors.

If you have any comments on the implementation, I'm all ears and hands :)