### PR TITLE
ISSUE 189 - Multiple enclosures in rss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 *.a
 *.so
 
+#vim stuff
+*.swp
+*.swo
+
 # Folders
 _obj
 _test

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rodmcelrath/gofeed
+module github.com/mmcdole/gofeed
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mmcdole/gofeed
+module github.com/rodmcelrath/gofeed
 
 go 1.14
 

--- a/rss/feed.go
+++ b/rss/feed.go
@@ -51,7 +51,7 @@ type Item struct {
 	Author        string                   `json:"author,omitempty"`
 	Categories    []*Category              `json:"categories,omitempty"`
 	Comments      string                   `json:"comments,omitempty"`
-	Enclosure     *Enclosure               `json:"enclosure,omitempty"`
+	Enclosures    []*Enclosure             `json:"enclosures,omitempty"`
 	GUID          *GUID                    `json:"guid,omitempty"`
 	PubDate       string                   `json:"pubDate,omitempty"`
 	PubDateParsed *time.Time               `json:"pubDateParsed,omitempty"`

--- a/rss/feed.go
+++ b/rss/feed.go
@@ -51,6 +51,7 @@ type Item struct {
 	Author        string                   `json:"author,omitempty"`
 	Categories    []*Category              `json:"categories,omitempty"`
 	Comments      string                   `json:"comments,omitempty"`
+	Enclosure     *Enclosure               `json:"enclosure,omitempty"`
 	Enclosures    []*Enclosure             `json:"enclosures,omitempty"`
 	GUID          *GUID                    `json:"guid,omitempty"`
 	PubDate       string                   `json:"pubDate,omitempty"`

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -319,6 +319,7 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 	item = &Item{}
 	extensions := ext.Extensions{}
 	categories := []*Category{}
+	enclosures := []*Enclosure{}
 
 	for {
 		tok, err := rp.base.NextTag(p)
@@ -401,7 +402,7 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 				if err != nil {
 					return nil, err
 				}
-				item.Enclosure = result
+				enclosures = append(enclosures, result)
 			} else if name == "guid" {
 				result, err := rp.parseGUID(p)
 				if err != nil {
@@ -425,6 +426,10 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 				item.Custom[name] = result
 			}
 		}
+	}
+
+	if len(enclosures) > 0 {
+		item.Enclosures = enclosures
 	}
 
 	if len(categories) > 0 {

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -402,6 +402,7 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 				if err != nil {
 					return nil, err
 				}
+				item.Enclosure = result
 				enclosures = append(enclosures, result)
 			} else if name == "guid" {
 				result, err := rp.parseGUID(p)

--- a/testdata/parser/rss/issue_36_enclosure_text.json
+++ b/testdata/parser/rss/issue_36_enclosure_text.json
@@ -1,13 +1,19 @@
 {
     "items": [
         {
-            "enclosures": [
-              {
+            "enclosure": {
                 "url": "http://example.org/podcast.mp3",
                 "length": "123456",
                 "type": "audio/mpeg"
-              }
+            },
+            "enclosures": [
+                {
+                    "url": "http://example.org/podcast.mp3",
+                    "length": "123456",
+                    "type": "audio/mpeg"
+                }
             ]
+
         }
     ],
     "version": "2.0"

--- a/testdata/parser/rss/issue_36_enclosure_text.json
+++ b/testdata/parser/rss/issue_36_enclosure_text.json
@@ -1,11 +1,13 @@
 {
     "items": [
         {
-            "enclosure": {
+            "enclosures": [
+              {
                 "url": "http://example.org/podcast.mp3",
                 "length": "123456",
                 "type": "audio/mpeg"
-            }
+              }
+            ]
         }
     ],
     "version": "2.0"

--- a/testdata/parser/rss/rss_channel_item_enclosure.json
+++ b/testdata/parser/rss/rss_channel_item_enclosure.json
@@ -1,12 +1,17 @@
 {
     "items": [
         {
-            "enclosures": [
-              {
+            "enclosure": {
                 "url": "http://example.org/podcast.mp3",
                 "length": "123456",
                 "type": "audio/mpeg"
-              }
+            },
+            "enclosures": [
+                {
+                    "url": "http://example.org/podcast.mp3",
+                    "length": "123456",
+                    "type": "audio/mpeg"
+                }
             ]
         }
     ],

--- a/testdata/parser/rss/rss_channel_item_enclosure.json
+++ b/testdata/parser/rss/rss_channel_item_enclosure.json
@@ -1,11 +1,13 @@
 {
     "items": [
         {
-            "enclosure": {
+            "enclosures": [
+              {
                 "url": "http://example.org/podcast.mp3",
                 "length": "123456",
                 "type": "audio/mpeg"
-            }
+              }
+            ]
         }
     ],
     "version": "2.0"

--- a/testdata/translator/rss/feed_item_enclosure_-_rss_channel_item_enclosure.json
+++ b/testdata/translator/rss/feed_item_enclosure_-_rss_channel_item_enclosure.json
@@ -3,16 +3,21 @@
   "feedVersion": "2.0",
   "items": [
     {
-      "enclosures": [
-        {
+      "enclosure": {
           "length": "78910",
-          "type": "image/jpeg",
+          "type": "audio/jpeg",
           "url": "http://example.org/podcast.jpg"
-        },
+      },
+      "enclosures": [
         {
           "length": "123456",
           "type": "audio/mpeg",
           "url": "http://example.org/podcast.mp3"
+        },
+        {
+          "length": "78910",
+          "type": "image/jpeg",
+          "url": "http://example.org/podcast.jpg"
         }
       ]
     }

--- a/testdata/translator/rss/feed_item_enclosures_-_rss_channel_item_enclosures.json
+++ b/testdata/translator/rss/feed_item_enclosures_-_rss_channel_item_enclosures.json
@@ -5,11 +5,6 @@
     {
       "enclosures": [
         {
-          "length": "78910",
-          "type": "image/jpeg",
-          "url": "http://example.org/podcast.jpg"
-        },
-        {
           "length": "123456",
           "type": "audio/mpeg",
           "url": "http://example.org/podcast.mp3"

--- a/testdata/translator/rss/feed_item_enclosures_-_rss_channel_item_enclosures.xml
+++ b/testdata/translator/rss/feed_item_enclosures_-_rss_channel_item_enclosures.xml
@@ -5,7 +5,6 @@ Description: item enclosure
   <channel>
     <item>
       <enclosure url="http://example.org/podcast.mp3" length="123456" type="audio/mpeg" />
-      <enclosure url="http://example.org/podcast.jpg" length="78910" type="image/jpeg" />
     </item>
   </channel>
 </rss>

--- a/translator.go
+++ b/translator.go
@@ -448,18 +448,6 @@ func (t *DefaultRSSTranslator) translateItemEnclosures(rssItem *rss.Item) (enclo
 			e.Length = enc.Length
 			enclosures = append(enclosures, e)
 		}
-
-		// Reverse the enclosures array - This looks funky...
-		// There is method to the madness - the parser seems to accumulate the
-		// last enclosure seen - code change accumulates them all.
-		// However for backward comatibility - we'll reverse this slice so the
-		// first one in the slice is the last one seen - so it shouldn't break
-		// anyone - backward compatibility for those depending on it.
-		// And frankly, I could care less, as long as I get them all.
-		for i, j := 0, len(enclosures)-1; i < j; i, j = i+1, j-1 {
-			enclosures[i], enclosures[j] = enclosures[j], enclosures[i]
-		}
-
 	}
 
 	if len(enclosures) == 0 {

--- a/translator.go
+++ b/translator.go
@@ -437,13 +437,35 @@ func (t *DefaultRSSTranslator) translateItemCategories(rssItem *rss.Item) (categ
 }
 
 func (t *DefaultRSSTranslator) translateItemEnclosures(rssItem *rss.Item) (enclosures []*Enclosure) {
-	if rssItem.Enclosure != nil {
-		e := &Enclosure{}
-		e.URL = rssItem.Enclosure.URL
-		e.Type = rssItem.Enclosure.Type
-		e.Length = rssItem.Enclosure.Length
-		enclosures = []*Enclosure{e}
+
+	if rssItem.Enclosures != nil && len(rssItem.Enclosures) > 0 {
+
+		// Accumulate the enclosures
+		for _, enc := range rssItem.Enclosures {
+			e := &Enclosure{}
+			e.URL = enc.URL
+			e.Type = enc.Type
+			e.Length = enc.Length
+			enclosures = append(enclosures, e)
+		}
+
+		// Reverse the enclosures array - This looks funky...
+		// There is method to the madness - the parser seems to accumulate the
+		// last enclosure seen - code change accumulates them all.
+		// However for backward comatibility - we'll reverse this slice so the
+		// first one in the slice is the last one seen - so it shouldn't break
+		// anyone - backward compatibility for those depending on it.
+		// And frankly, I could care less, as long as I get them all.
+		for i, j := 0, len(enclosures)-1; i < j; i, j = i+1, j-1 {
+			enclosures[i], enclosures[j] = enclosures[j], enclosures[i]
+		}
+
 	}
+
+	if len(enclosures) == 0 {
+		enclosures = nil
+	}
+
 	return
 }
 


### PR DESCRIPTION
Multiple enclosures in RSS are not handled.
Rather we get the last one.

1. Added Multiple enclosure handling to RSS and translator.
2. Updated test data.
3. Added specific test coverage for multiple enclosures.

Note: since the RSS parser seemed to accumulate the last enclosure,
and select that one. I reversed the accumulation array, so that,
anyone expecting the old behavior would not be surprised.