### PR TITLE
Make XMLBase thread-safe

### DIFF
--- a/atom/feed.go
+++ b/atom/feed.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/mmcdole/gofeed/extensions"
+	"github.com/mmcdole/gofeed/internal/shared"
 )
 
 // Feed is an Atom Feed
@@ -26,6 +27,8 @@ type Feed struct {
 	Entries       []*Entry       `json:"entries"`
 	Extensions    ext.Extensions `json:"extensions,omitempty"`
 	Version       string         `json:"version"`
+
+	xmlBase shared.XMLBase
 }
 
 func (f Feed) String() string {

--- a/rss/feed.go
+++ b/rss/feed.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	ext "github.com/mmcdole/gofeed/extensions"
+	"github.com/mmcdole/gofeed/internal/shared"
 )
 
 // Feed is an RSS Feed
@@ -36,6 +37,8 @@ type Feed struct {
 	Extensions          ext.Extensions           `json:"extensions,omitempty"`
 	Items               []*Item                  `json:"items"`
 	Version             string                   `json:"version"`
+
+	xmlBase shared.XMLBase
 }
 
 func (f Feed) String() string {


### PR DESCRIPTION
Hey @mmcdole -

I'm the original author of the XMLBase code (#101). I've recently returned to using gofeed in a new project and noticed that my xmlbase implementation is the source of some concurrency issues (#159 , #160 ). One way to allow Parser to be used concurrently would be to have each Feed manager its own urlStack instead of having a single shared urlStack managed by Parser. That's what this PR does. (The first commit is a test which uses a Parser from several go routines; when run with `go test -race` it should fail without the second commit and pass with the commit applied.)