### PR TITLE
accept empty xml space for content:encoded

### DIFF
--- a/rss/parser.go
+++ b/rss/parser.go
@@ -357,7 +357,7 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 				item.Description = result
 			} else if name == "encoded" {
 				space := strings.TrimSpace(p.Space)
-				if prefix, ok := p.Spaces[space]; ok && prefix == "content" {
+				if prefix, ok := p.Spaces[space]; ok && (prefix == "content" || prefix == "") {
 					result, err := shared.ParseText(p)
 					if err != nil {
 						return nil, err

--- a/testdata/parser/rss/rss_channel_item_content_encoded.json
+++ b/testdata/parser/rss/rss_channel_item_content_encoded.json
@@ -1,0 +1,8 @@
+{
+    "items": [
+        {
+            "content": "Item Description"
+        }
+    ],
+    "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_item_content_encoded.xml
+++ b/testdata/parser/rss/rss_channel_item_content_encoded.xml
@@ -1,0 +1,11 @@
+<!--
+Description: rss item content encoded 
+-->
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+    <channel>
+      <item>
+        <content:encoded xmlns="http://purl.org/rss/1.0/modules/content/">Item Description</content:encoded>
+      </item>
+    </channel>
+  </rss>
+  


### PR DESCRIPTION
in some cases, the space is empty to use the tag namespace as default. To manage this I have added an OR conditions in rss/parser.go.

Alternative: improve goxpp to use tag namespace as xmlns default if empty ?