### PR TITLE
Update translator.go

### DIFF
--- a/translator.go
+++ b/translator.go
@@ -641,7 +641,11 @@ func (t *DefaultAtomTranslator) translateFeedCategories(atom *atom.Feed) (catego
 	if atom.Categories != nil {
 		categories = []string{}
 		for _, c := range atom.Categories {
-			categories = append(categories, c.Term)
+			if c.Label != "" {
+				categories = append(categories, c.Label)
+			} else {
+				categories = append(categories, c.Term)
+			}
 		}
 	}
 	return
@@ -746,7 +750,11 @@ func (t *DefaultAtomTranslator) translateItemCategories(entry *atom.Entry) (cate
 	if entry.Categories != nil {
 		categories = []string{}
 		for _, c := range entry.Categories {
-			categories = append(categories, c.Term)
+			if c.Label != "" {
+				categories = append(categories, c.Label)
+			} else {
+				categories = append(categories, c.Term)
+			}
 		}
 	}
 	return


### PR DESCRIPTION
I change the category atom translation from term to label, because there are feeds, which use the term as slug and prefix them with e.g. `t:`, but the label is the tag name then. When translating an atom feed to a generic feed, this would help to get more cleaner categories since the label does not have any prefix.