### PR TITLE
Extract feed and item images from more places

### DIFF
--- a/extensions/extensions_test.go
+++ b/extensions/extensions_test.go
@@ -44,3 +44,36 @@ func TestITunes_Extensions(t *testing.T) {
 		}
 	}
 }
+
+
+func TestMedia_Extensions(t *testing.T) {
+	files, _ := filepath.Glob("../testdata/extensions/media/*.xml")
+	for _, f := range files {
+		base := filepath.Base(f)
+		name := strings.TrimSuffix(base, filepath.Ext(base))
+
+		fmt.Printf("Testing %s... ", name)
+
+		// Get actual source feed
+		ff := fmt.Sprintf("../testdata/extensions/media/%s.xml", name)
+		f, _ := os.ReadFile(ff)
+
+		// Parse actual feed
+		fp := gofeed.NewParser()
+		actual, _ := fp.Parse(bytes.NewReader(f))
+
+		// Get json encoded expected feed result
+		ef := fmt.Sprintf("../testdata/extensions/media/%s.json", name)
+		e, _ := os.ReadFile(ef)
+
+		// Unmarshal expected feed
+		expected := &gofeed.Feed{}
+		json.Unmarshal(e, &expected)
+
+		if assert.Equal(t, expected, actual, "Feed file %s.xml did not match expected output %s.json", name, name) {
+			fmt.Printf("OK\n")
+		} else {
+			fmt.Printf("Failed\n")
+		}
+	}
+}

--- a/testdata/extensions/media/feed_image_-_rss_channel_media.json
+++ b/testdata/extensions/media/feed_image_-_rss_channel_media.json
@@ -1,0 +1,22 @@
+{
+  "feedType": "rss",
+  "feedVersion": "0.91",
+  "image": {
+    "url": "http://example.com/channel.png"
+  },
+  "extensions": {
+    "media": {
+      "content": [
+        {
+          "name": "content",
+          "attrs": {
+            "url": "http://example.com/channel.png",
+            "medium": "image"
+          },
+          "children": {}
+        }
+      ]
+    }
+  },
+  "items": []
+}

--- a/testdata/extensions/media/feed_image_-_rss_channel_media.xml
+++ b/testdata/extensions/media/feed_image_-_rss_channel_media.xml
@@ -1,0 +1,8 @@
+<!--
+Description: channel image
+-->
+<rss version="0.91">
+  <channel>
+    <media:content url="http://example.com/channel.png" medium="image"></media:content>
+  </channel>
+</rss>

--- a/testdata/extensions/media/feed_item_image_-_rss_channel_item_media.json
+++ b/testdata/extensions/media/feed_item_image_-_rss_channel_item_media.json
@@ -1,0 +1,39 @@
+{
+    "items": [
+        {
+            "title": "rss item image from media content",
+            "image": {
+                "url": "https://example.com/blog-open.png",
+                "title": ""
+            },
+            "extensions": {
+                "media": {
+                    "content": [
+                        {
+                            "name": "content",
+                            "value": "",
+                            "attrs": {
+                                "medium": "image",
+                                "url": "https://example.com/blog-open.png"
+                            },
+                            "children": {
+                                "title": [
+                                    {
+                                        "name": "title",
+                                        "value": "blog-open",
+                                        "attrs": {
+                                            "type": "html"
+                                        },
+                                        "children": {}
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "feedType": "rss",
+    "feedVersion": "2.0"
+}

--- a/testdata/extensions/media/feed_item_image_-_rss_channel_item_media.xml
+++ b/testdata/extensions/media/feed_item_image_-_rss_channel_item_media.xml
@@ -1,0 +1,13 @@
+<!--
+Description: rss item image from media content
+-->
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>rss item image from media content</title>
+      <media:content url="https://example.com/blog-open.png" medium="image">
+        <media:title type="html">blog-open</media:title>
+      </media:content>
+    </item>
+  </channel>
+</rss>

--- a/testdata/translator/rss/feed_image_-_rss_channel_description.json
+++ b/testdata/translator/rss/feed_image_-_rss_channel_description.json
@@ -1,0 +1,9 @@
+{
+  "feedType": "rss",
+  "feedVersion": "0.91",
+  "description": "<img src=\"http://example.com/description.png\">",
+  "image": {
+    "url": "http://example.com/description.png"
+  },
+  "items": []
+}

--- a/testdata/translator/rss/feed_image_-_rss_channel_description.xml
+++ b/testdata/translator/rss/feed_image_-_rss_channel_description.xml
@@ -1,0 +1,8 @@
+<!--
+Description: channel image
+-->
+<rss version="0.91">
+  <channel>
+    <description><![CDATA[<img src="http://example.com/description.png">]]></description>
+  </channel>
+</rss>

--- a/testdata/translator/rss/feed_item_enclosure_-_rss_channel_item_enclosure.json
+++ b/testdata/translator/rss/feed_item_enclosure_-_rss_channel_item_enclosure.json
@@ -8,6 +8,10 @@
           "type": "audio/jpeg",
           "url": "http://example.org/podcast.jpg"
       },
+      "image": {
+        "url": "http://example.org/podcast.jpg",
+        "title": ""
+      },
       "enclosures": [
         {
           "length": "123456",

--- a/testdata/translator/rss/feed_item_image_-_rss_channel_item_content.json
+++ b/testdata/translator/rss/feed_item_image_-_rss_channel_item_content.json
@@ -1,0 +1,12 @@
+{
+  "feedType": "rss",
+  "feedVersion": "0.91",
+  "items": [
+    {
+      "image": {
+        "url": "http://example.com/content.png"
+      },
+      "content": "<img src=\"http://example.com/content.png\">"
+    }
+  ]
+}

--- a/testdata/translator/rss/feed_item_image_-_rss_channel_item_content.xml
+++ b/testdata/translator/rss/feed_item_image_-_rss_channel_item_content.xml
@@ -1,0 +1,10 @@
+<!--
+Description: item image from content
+-->
+<rss version="0.91">
+  <channel>
+    <item>
+      <content><![CDATA[<img src="http://example.com/content.png">]]></content>
+    </item>
+  </channel>
+</rss>

--- a/testdata/translator/rss/feed_item_image_-_rss_channel_item_description.json
+++ b/testdata/translator/rss/feed_item_image_-_rss_channel_item_description.json
@@ -1,0 +1,12 @@
+{
+  "feedType": "rss",
+  "feedVersion": "0.91",
+  "items": [
+    {
+      "image": {
+        "url": "http://example.com/description.png"
+      },
+      "description": "<img src=\"http://example.com/description.png\">"
+    }
+  ]
+}

--- a/testdata/translator/rss/feed_item_image_-_rss_channel_item_description.xml
+++ b/testdata/translator/rss/feed_item_image_-_rss_channel_item_description.xml
@@ -1,0 +1,10 @@
+<!--
+Description: item image from description
+-->
+<rss version="0.91">
+  <channel>
+    <item>
+      <description><![CDATA[<img src="http://example.com/description.png">]]></description>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
Additional locations where images are attempted to be extracted:

* media:content extension https://www.rssboard.org/media-rss#media-content
* The first `<img>` in content or description

Fixes #133