### PR TITLE
Added fallback to atom icon when atom logo is missing

### DIFF
--- a/testdata/translator/atom/feed_image_-_atom10_feed_icon.json
+++ b/testdata/translator/atom/feed_image_-_atom10_feed_icon.json
@@ -1,0 +1,8 @@
+{
+    "image": {
+        "url": "http://example.org/icon.jpg"
+    },
+    "items": [],
+    "feedType": "atom",
+    "feedVersion": "1.0"
+}

--- a/testdata/translator/atom/feed_image_-_atom10_feed_icon.xml
+++ b/testdata/translator/atom/feed_image_-_atom10_feed_icon.xml
@@ -1,7 +1,6 @@
 <!--
-Description: feed logo
+Description: feed icon
 -->
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <logo>http://example.org/logo.jpg</logo>
   <icon>http://example.org/icon.jpg</icon>
 </feed>

--- a/translator.go
+++ b/translator.go
@@ -613,6 +613,10 @@ func (t *DefaultAtomTranslator) translateFeedImage(atom *atom.Feed) (image *Imag
 		feedImage := Image{}
 		feedImage.URL = atom.Logo
 		image = &feedImage
+	} else if atom.Icon != "" {
+		feedImage := Image{}
+		feedImage.URL = atom.Icon
+		image = &feedImage
 	}
 	return
 }


### PR DESCRIPTION
First off, fantastic library! :clap:  Great job.

While integrating it into [Feeder](https://github.com/spacecowboy/feeder) (my Android feed reader) one of my unit tests failed. :disappointed: 

This PR would make the test pass in my project. What do you think?

For reference, it is this assertion: https://github.com/spacecowboy/Feeder/blob/master/app/src/test/java/com/nononsenseapps/feeder/model/FeedParserTest.kt#L673

Which parses the file at: https://github.com/spacecowboy/Feeder/blob/master/app/src/test/resources/com/nononsenseapps/feeder/model/atom_cowboy.xml