### PR TITLE
Atom: use correct xml:base for decoded elements

### DIFF
--- a/atom/parser.go
+++ b/atom/parser.go
@@ -658,20 +658,12 @@ func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
 		InnerXML string `xml:",innerxml"`
 	}
 
-    // DecodeElement pops the base stack if the element contains an xml:base
-    // attribute, so we need to save and restore it before resolving any
-    // relative URLs below
-	oldBase := p.BaseStack
+	// get current base URL before it is clobbered by DecodeElement
+	base := p.BaseStack.Top()
 	err := p.DecodeElement(&text)
 	if err != nil {
 		return "", err
 	}
-	newBase := p.BaseStack
-	p.BaseStack = oldBase
-	defer func() {
-		// pop base when we're done with the decoded element
-		p.BaseStack = newBase
-	}()
 
 	result := text.InnerXML
 	result = strings.TrimSpace(result)
@@ -682,7 +674,7 @@ func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
 	if strings.Contains(result, "<![CDATA[") {
 		result = shared.StripCDATA(result)
 		if lowerType == "html" || strings.Contains(lowerType, "xhtml") {
-			result, _ = shared.ResolveHTML(p, result)
+			result, _ = shared.ResolveHTML(base, result)
 		}
 	} else {
 		// decode non-CDATA contents depending on type
@@ -693,12 +685,12 @@ func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
 			result, err = shared.DecodeEntities(result)
 		} else if strings.Contains(lowerType, "xhtml") {
 			result = ap.stripWrappingDiv(result)
-			result, _ = shared.ResolveHTML(p, result)
+			result, _ = shared.ResolveHTML(base, result)
 		} else if lowerType == "html" {
 			result = ap.stripWrappingDiv(result)
 			result, err = shared.DecodeEntities(result)
 			if err == nil {
-				result, _ = shared.ResolveHTML(p, result)
+				result, _ = shared.ResolveHTML(base, result)
 			}
 		} else {
 			decodedStr, err := base64.StdEncoding.DecodeString(result)
@@ -711,7 +703,7 @@ func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
 	// resolve relative URIs in URI-containing elements according to xml:base
 	name := strings.ToLower(p.Name)
 	if atomUriElements[name] {
-		resolved, err := p.XmlBaseResolveUrl(result)
+		resolved, err := shared.XmlBaseResolveUrl(base, result)
 		if resolved != nil && err == nil {
 			result = resolved.String()
 		}

--- a/atom/parser.go
+++ b/atom/parser.go
@@ -658,10 +658,20 @@ func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
 		InnerXML string `xml:",innerxml"`
 	}
 
+    // DecodeElement pops the base stack if the element contains an xml:base
+    // attribute, so we need to save and restore it before resolving any
+    // relative URLs below
+	oldBase := p.BaseStack
 	err := p.DecodeElement(&text)
 	if err != nil {
 		return "", err
 	}
+	newBase := p.BaseStack
+	p.BaseStack = oldBase
+	defer func() {
+		// pop base when we're done with the decoded element
+		p.BaseStack = newBase
+	}()
 
 	result := text.InnerXML
 	result = strings.TrimSpace(result)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/PuerkitoBio/goquery v1.8.0
 	github.com/json-iterator/go v1.1.12
-	github.com/mmcdole/goxpp v1.1.0
+	github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli v1.22.3
 	golang.org/x/net v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/mmcdole/goxpp v1.1.0 h1:WwslZNF7KNAXTFuzRtn/OKZxFLJAAyOA9w82mDz2ZGI=
-github.com/mmcdole/goxpp v1.1.0/go.mod h1:v+25+lT2ViuQ7mVxcncQ8ch1URund48oH+jhjiwEgS8=
+github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23 h1:Zr92CAlFhy2gL+V1F+EyIuzbQNbSgP4xhTODZtrXUtk=
+github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23/go.mod h1:v+25+lT2ViuQ7mVxcncQ8ch1URund48oH+jhjiwEgS8=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
The issue is that goxpp's DecodeElement() pop's the BaseStack after unmarshaling an element -- as it should to keep the BaseStack in sync with the current document scope. But that means the atom parser needs to keep a reference to the current base before calling DecodeElement() so that it can correctly resolve URLs.

Without this fix, elements with xml:base attributes will be erroneously resolved with the parent xml:base.

This fix is a little awkward with all of its saving and restoring of BaseStacks. A simpler solution would be to simply get the `xml:base` attribute from the decoded element and resolve against that. However, that would require changes to `goxpp`: either change `XmlBaseResolveUrl()` to accept a string rather than acting as a method, or maybe adding a separate `ResolveUrl()` function that takes a base and a relative URL that `gofeed` could use.