### PR TITLE
Make Feed keep and expose a reference to the original feed object

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -36,11 +36,25 @@ type Feed struct {
 	Items           []*Item                  `json:"items"`
 	FeedType        string                   `json:"feedType"`
 	FeedVersion     string                   `json:"feedVersion"`
+
+	originalFeed interface{}
 }
 
 func (f Feed) String() string {
 	json, _ := json.MarshalIndent(f, "", "    ")
 	return string(json)
+}
+
+// OriginalFeed returns the source feed object if
+// this Feed was translated from an RSS, Atom, or
+// json feed type by the default translators, else
+// it returns null. This provides access to
+// feed-specific fields and features at
+// translation time, but the original feed data is
+// not preserved through a
+// serialization/deserialization cycle.
+func (f Feed) OriginalFeed() interface{} {
+	return f.originalFeed
 }
 
 // Item is the universal Item type that atom.Entry

--- a/translator.go
+++ b/translator.go
@@ -38,6 +38,7 @@ func (t *DefaultRSSTranslator) Translate(feed interface{}) (*Feed, error) {
 	}
 
 	result := &Feed{}
+	result.originalFeed = rss
 	result.Title = t.translateFeedTitle(rss)
 	result.Description = t.translateFeedDescription(rss)
 	result.Link = t.translateFeedLink(rss)
@@ -543,6 +544,7 @@ func (t *DefaultAtomTranslator) Translate(feed interface{}) (*Feed, error) {
 	}
 
 	result := &Feed{}
+	result.originalFeed = atom
 	result.Title = t.translateFeedTitle(atom)
 	result.Description = t.translateFeedDescription(atom)
 	result.Link = t.translateFeedLink(atom)
@@ -871,6 +873,7 @@ func (t *DefaultJSONTranslator) Translate(feed interface{}) (*Feed, error) {
 	}
 
 	result := &Feed{}
+	result.originalFeed = json
 	result.FeedVersion = json.Version
 	result.Title = t.translateFeedTitle(json)
 	result.Link = t.translateFeedLink(json)


### PR DESCRIPTION
Call Feed.OriginalFeed() to get the original feed if available.

Fixes #229

I just threw this together real quick to see what you think about it.