### PR TITLE
Handle links prefixed with spaces in atom

### DIFF
--- a/internal/shared/xmlbase.go
+++ b/internal/shared/xmlbase.go
@@ -98,7 +98,7 @@ func resolveAttrs(p *xpp.XMLPullParser) error {
 
 // resolve u relative to b
 func XmlBaseResolveUrl(b *url.URL, u string) (*url.URL, error) {
-	relURL, err := url.Parse(u)
+	relURL, err := url.Parse(strings.TrimLeft(u, " "))
 	if err != nil {
 		return nil, err
 	}

--- a/testdata/parser/atom/atom10_feed_entry_link_href_invalid_space_prefix.json
+++ b/testdata/parser/atom/atom10_feed_entry_link_href_invalid_space_prefix.json
@@ -1,0 +1,13 @@
+{
+    "entries": [
+        {
+            "links": [
+                {
+                    "rel": "alternate",
+                    "href": "http://example.org"
+                }
+            ]
+        }
+    ],
+    "version": "1.0"
+}

--- a/testdata/parser/atom/atom10_feed_entry_link_href_invalid_space_prefix.xml
+++ b/testdata/parser/atom/atom10_feed_entry_link_href_invalid_space_prefix.xml
@@ -1,0 +1,8 @@
+<!--
+Description: entry link - space prefixed href
+-->
+<feed xmlns="http://www.w3.org/2005/Atom">
+	<entry>
+		<link href=" http://example.org"></link>
+	</entry>
+</feed>


### PR DESCRIPTION
handles malformed atom with links like 
```
		<link href=" http://example.org"></link>
```
i.e. space between " and http 
real world sample https://www.php.net/feed.atom 
```
  <entry xmlns="http://www.w3.org/2005/Atom" xmlns:default="http://php.net/ns/news" xml:base="entries/2020-02-17-1.xml">
  <title>LoopRun Barcelona 2020</title>
  <id>https://www.php.net/archive/2020.php#2020-02-17-1</id>
  <published>2020-02-17T11:52:20+01:00</published>
  <updated>2020-02-17T11:52:20+01:00</updated>
  <link href="https://www.php.net/conferences/index.php#id2020-02-17-1" rel="alternate" type="text/html"/>
  <link href=" https://loop-run.io" rel="via" type="text/html"/>
```


