### PR TITLE
Fix parsing failure with non-HTTP URI schemes

### DIFF
--- a/internal/shared/xmlbase.go
+++ b/internal/shared/xmlbase.go
@@ -85,12 +85,10 @@ func resolveAttrs(p *xpp.XMLPullParser) error {
 		lowerName := strings.ToLower(attr.Name.Local)
 		if uriAttrs[lowerName] {
 			absURL, err := XmlBaseResolveUrl(p.BaseStack.Top(), attr.Value)
-			if err != nil {
-				return err
-			}
-			if absURL != nil {
+			if err == nil && absURL != nil {
 				p.Attrs[i].Value = absURL.String()
 			}
+			// Continue processing even if URL resolution fails (e.g., for non-HTTP URIs like at://)
 		}
 	}
 	return nil

--- a/testdata/parser/rss/rss_channel_item_uri_at_protocol.json
+++ b/testdata/parser/rss/rss_channel_item_uri_at_protocol.json
@@ -1,0 +1,19 @@
+{
+    "title": "Test Feed",
+    "link": "http://example.com",
+    "links": [
+        "http://example.com"
+    ],
+    "description": "Test Description",
+    "items": [
+        {
+            "title": "Test Item",
+            "link": "http://example.com/item",
+            "links": [
+                "http://example.com/item"
+            ],
+            "description": "Test item description"
+        }
+    ],
+    "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_item_uri_at_protocol.xml
+++ b/testdata/parser/rss/rss_channel_item_uri_at_protocol.xml
@@ -1,0 +1,15 @@
+<!--
+Description: rss item with AT Protocol URI that should not fail parsing
+-->
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <description>Test Description</description>
+    <link>http://example.com</link>
+    <item>
+      <title>Test Item</title>
+      <description>Test item description</description>
+      <link uri="at://did:plc:pzznkrzajsaqev3ffamg3jnr/app.bsky.feed.post/3ljkhwqun7l2b">http://example.com/item</link>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
Continue processing when URI attribute resolution fails instead of halting the entire feed parse. This allows feeds containing AT Protocol URIs, mailto: links, and other non-HTTP schemes to parse successfully.

Fixes #236