### PR TITLE
ci: Add v2 branch to GitHub Actions workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,9 +5,9 @@ name: Go
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "v2" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "v2" ]
 
 jobs:
 


### PR DESCRIPTION
## Summary
Updates the GitHub Actions workflow to also run on the v2 branch and PRs targeting v2.

## Changes
- Add "v2" to the list of branches that trigger workflows on push
- Add "v2" to the list of branches that trigger workflows on pull requests

## Reason
Currently, the v2 development branch and PRs targeting it (like #251) don't have CI coverage because the workflow only runs for the master branch.

This change ensures that:
- All commits pushed to v2 will be tested
- All PRs targeting v2 will have checks run
- We maintain code quality during v2 development