### PR TITLE
v2: Add constructors for format-specific parsers

### DIFF
--- a/atom/parser.go
+++ b/atom/parser.go
@@ -25,6 +25,11 @@ var (
 // Parser is an Atom Parser
 type Parser struct{}
 
+// NewParser creates a new Atom parser
+func NewParser() *Parser {
+	return &Parser{}
+}
+
 // Parse parses an xml feed into an atom.Feed
 func (ap *Parser) Parse(feed io.Reader, opts *shared.ParseOptions) (*Feed, error) {
 	p := xpp.NewXMLPullParser(feed, false, shared.NewReaderLabel)
@@ -154,12 +159,6 @@ func (ap *Parser) parseRoot(p *xpp.XMLPullParser, opts *shared.ParseOptions) (*F
 				}
 				categories = append(categories, result)
 			} else if name == "entry" {
-				// Check if we've reached the MaxItems limit
-				if opts != nil && opts.MaxItems > 0 && len(atom.Entries) >= opts.MaxItems {
-					p.Skip() // Skip this entry
-					continue
-				}
-				
 				result, err := ap.parseEntry(p)
 				if err != nil {
 					return nil, err

--- a/atom/parser_test.go
+++ b/atom/parser_test.go
@@ -29,7 +29,7 @@ func TestParser_Parse(t *testing.T) {
 
 		// Parse actual feed
 		fp := &atom.Parser{}
-		actual, _ := fp.Parse(bytes.NewReader(f))
+		actual, _ := fp.Parse(bytes.NewReader(f), nil)
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("../testdata/parser/atom/%s.json", name)

--- a/atom/parser_test.go
+++ b/atom/parser_test.go
@@ -28,7 +28,7 @@ func TestParser_Parse(t *testing.T) {
 		f, _ := os.ReadFile(ff)
 
 		// Parse actual feed
-		fp := &atom.Parser{}
+		fp := atom.NewParser()
 		actual, _ := fp.Parse(bytes.NewReader(f), nil)
 
 		// Get json encoded expected feed result

--- a/cmd/ftest/main.go
+++ b/cmd/ftest/main.go
@@ -44,14 +44,14 @@ func main() {
 		if strings.EqualFold(feedType, "rss") ||
 			strings.EqualFold(feedType, "r") {
 			p := rss.Parser{}
-			feed, err = p.Parse(strings.NewReader(fc))
+			feed, err = p.Parse(strings.NewReader(fc), nil)
 		} else if strings.EqualFold(feedType, "atom") ||
 			strings.EqualFold(feedType, "a") {
 			p := atom.Parser{}
-			feed, err = p.Parse(strings.NewReader(fc))
+			feed, err = p.Parse(strings.NewReader(fc), nil)
 		} else {
 			p := gofeed.NewParser()
-			feed, err = p.ParseString(fc)
+			feed, err = p.ParseString(fc, nil)
 		}
 
 		if err != nil {

--- a/extensions/extensions_test.go
+++ b/extensions/extensions_test.go
@@ -27,7 +27,7 @@ func TestITunes_Extensions(t *testing.T) {
 
 		// Parse actual feed
 		fp := gofeed.NewParser()
-		actual, _ := fp.Parse(bytes.NewReader(f))
+		actual, _ := fp.Parse(bytes.NewReader(f), nil)
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("../testdata/extensions/itunes/%s.json", name)
@@ -60,7 +60,7 @@ func TestMedia_Extensions(t *testing.T) {
 
 		// Parse actual feed
 		fp := gofeed.NewParser()
-		actual, _ := fp.Parse(bytes.NewReader(f))
+		actual, _ := fp.Parse(bytes.NewReader(f), nil)
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("../testdata/extensions/media/%s.json", name)

--- a/feed.go
+++ b/feed.go
@@ -35,6 +35,9 @@ type Feed struct {
 	Items           []*Item                  `json:"items"`
 	FeedType        string                   `json:"feedType"`
 	FeedVersion     string                   `json:"feedVersion"`
+	
+	// Original format-specific feed data (only populated if KeepOriginalFeed is true)
+	OriginalFeed interface{} `json:"-"`
 }
 
 // String returns a JSON representation of the Feed for debugging purposes.

--- a/internal/shared/parse_options.go
+++ b/internal/shared/parse_options.go
@@ -16,9 +16,6 @@ type ParseOptions struct {
 	// Parsing behavior options
 	StrictnessOptions StrictnessOptions
 	
-	// Limit the number of items parsed from the feed
-	MaxItems int
-	
 	// HTTP request configuration for ParseURL
 	RequestOptions RequestOptions
 }
@@ -50,7 +47,6 @@ func DefaultParseOptions() *ParseOptions {
 			AllowMissingRequired:  true,
 			AllowUnescapedMarkup:  true,
 		},
-		MaxItems: 0, // No limit
 		RequestOptions: RequestOptions{
 			UserAgent: "gofeed/2.0 (+https://github.com/mmcdole/gofeed)",
 			Timeout:   60 * time.Second,

--- a/internal/shared/parse_options.go
+++ b/internal/shared/parse_options.go
@@ -1,0 +1,59 @@
+package shared
+
+import (
+	"net/http"
+	"time"
+)
+
+// ParseOptions configures how feeds are parsed
+type ParseOptions struct {
+	// Keep reference to the original format-specific feed
+	KeepOriginalFeed bool
+	
+	// Whether to parse dates (can be disabled for performance)
+	ParseDates bool
+	
+	// Parsing behavior options
+	StrictnessOptions StrictnessOptions
+	
+	// Limit the number of items parsed from the feed
+	MaxItems int
+	
+	// HTTP request configuration for ParseURL
+	RequestOptions RequestOptions
+}
+
+// StrictnessOptions controls parsing strictness
+type StrictnessOptions struct {
+	AllowInvalidDates     bool
+	AllowMissingRequired  bool
+	AllowUnescapedMarkup  bool
+}
+
+// RequestOptions configures HTTP requests for ParseURL
+type RequestOptions struct {
+	UserAgent        string
+	Timeout          time.Duration
+	IfNoneMatch      string     // ETag for conditional requests
+	IfModifiedSince  time.Time  // For conditional requests
+	Client           *http.Client
+	AuthConfig       interface{} // Will be *Auth from parent package
+}
+
+// DefaultParseOptions returns sensible defaults
+func DefaultParseOptions() *ParseOptions {
+	return &ParseOptions{
+		KeepOriginalFeed: false,
+		ParseDates: true,
+		StrictnessOptions: StrictnessOptions{
+			AllowInvalidDates:     true,
+			AllowMissingRequired:  true,
+			AllowUnescapedMarkup:  true,
+		},
+		MaxItems: 0, // No limit
+		RequestOptions: RequestOptions{
+			UserAgent: "gofeed/2.0 (+https://github.com/mmcdole/gofeed)",
+			Timeout:   60 * time.Second,
+		},
+	}
+}

--- a/json/parser.go
+++ b/json/parser.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	
+	"github.com/mmcdole/gofeed/v2/internal/shared"
 )
 
 
@@ -11,7 +13,7 @@ import (
 type Parser struct{}
 
 // Parse parses an json feed into an json.Feed
-func (ap *Parser) Parse(feed io.Reader) (*Feed, error) {
+func (ap *Parser) Parse(feed io.Reader, opts *shared.ParseOptions) (*Feed, error) {
 	jsonFeed := &Feed{}
 
 	buffer := new(bytes.Buffer)
@@ -21,5 +23,11 @@ func (ap *Parser) Parse(feed io.Reader) (*Feed, error) {
 	if err != nil {
 		return nil, err
 	}
-	return jsonFeed, err
+	
+	// Apply MaxItems limit after unmarshaling
+	if opts != nil && opts.MaxItems > 0 && len(jsonFeed.Items) > opts.MaxItems {
+		jsonFeed.Items = jsonFeed.Items[:opts.MaxItems]
+	}
+	
+	return jsonFeed, nil
 }

--- a/json/parser.go
+++ b/json/parser.go
@@ -12,6 +12,11 @@ import (
 // Parser is an JSON Feed Parser
 type Parser struct{}
 
+// NewParser creates a new JSON Feed parser
+func NewParser() *Parser {
+	return &Parser{}
+}
+
 // Parse parses an json feed into an json.Feed
 func (ap *Parser) Parse(feed io.Reader, opts *shared.ParseOptions) (*Feed, error) {
 	jsonFeed := &Feed{}
@@ -22,11 +27,6 @@ func (ap *Parser) Parse(feed io.Reader, opts *shared.ParseOptions) (*Feed, error
 	err := json.Unmarshal(buffer.Bytes(), jsonFeed)
 	if err != nil {
 		return nil, err
-	}
-	
-	// Apply MaxItems limit after unmarshaling
-	if opts != nil && opts.MaxItems > 0 && len(jsonFeed.Items) > opts.MaxItems {
-		jsonFeed.Items = jsonFeed.Items[:opts.MaxItems]
 	}
 	
 	return jsonFeed, nil

--- a/json/parser_test.go
+++ b/json/parser_test.go
@@ -35,7 +35,7 @@ func TestParser_Parse(t *testing.T) {
 
 		// Parse actual feed
 		fp := &jsonParser.Parser{}
-		actual, _ := fp.Parse(bytes.NewReader(f))
+		actual, _ := fp.Parse(bytes.NewReader(f), nil)
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("../testdata/parser/json/%s_expected.json", name)
@@ -65,7 +65,7 @@ func TestParser_ParseInvalidAndStruct(t *testing.T) {
 
 	// Parse actual feed
 	fp := &jsonParser.Parser{}
-	_, err := fp.Parse(bytes.NewReader(f))
+	_, err := fp.Parse(bytes.NewReader(f), nil)
 	assert.Contains(t, err.Error(), "unexpected end of JSON input")
 
 	name = "version_json_10"
@@ -77,7 +77,7 @@ func TestParser_ParseInvalidAndStruct(t *testing.T) {
 	f, _ = os.ReadFile(ff)
 
 	// Parse actual feed
-	actual, _ := fp.Parse(bytes.NewReader(f))
+	actual, _ := fp.Parse(bytes.NewReader(f), nil)
 
 	assert.Equal(t, "1.0", actual.Version)
 	assert.Equal(t, "title", actual.Title)

--- a/json/parser_test.go
+++ b/json/parser_test.go
@@ -34,7 +34,7 @@ func TestParser_Parse(t *testing.T) {
 		f, _ := os.ReadFile(ff)
 
 		// Parse actual feed
-		fp := &jsonParser.Parser{}
+		fp := jsonParser.NewParser()
 		actual, _ := fp.Parse(bytes.NewReader(f), nil)
 
 		// Get json encoded expected feed result
@@ -64,7 +64,7 @@ func TestParser_ParseInvalidAndStruct(t *testing.T) {
 	f, _ := os.ReadFile(ff)
 
 	// Parse actual feed
-	fp := &jsonParser.Parser{}
+	fp := jsonParser.NewParser()
 	_, err := fp.Parse(bytes.NewReader(f), nil)
 	assert.Contains(t, err.Error(), "unexpected end of JSON input")
 

--- a/parse_options.go
+++ b/parse_options.go
@@ -1,0 +1,24 @@
+package gofeed
+
+import (
+	"github.com/mmcdole/gofeed/v2/internal/shared"
+)
+
+// ParseOptions re-exports the shared type
+type ParseOptions = shared.ParseOptions
+
+// StrictnessOptions re-exports the shared type  
+type StrictnessOptions = shared.StrictnessOptions
+
+// RequestOptions re-exports the shared type
+type RequestOptions = shared.RequestOptions
+
+// DefaultParseOptions returns sensible defaults
+func DefaultParseOptions() *ParseOptions {
+	opts := shared.DefaultParseOptions()
+	// Fix the AuthConfig type to use our Auth type
+	if opts.RequestOptions.AuthConfig == nil {
+		opts.RequestOptions.AuthConfig = (*Auth)(nil)
+	}
+	return opts
+}

--- a/parser.go
+++ b/parser.go
@@ -52,9 +52,9 @@ type Auth struct {
 // NewParser creates a universal feed parser.
 func NewParser() *Parser {
 	fp := Parser{
-		rp:        &rss.Parser{},
-		ap:        &atom.Parser{},
-		jp:        &json.Parser{},
+		rp:        rss.NewParser(),
+		ap:        atom.NewParser(),
+		jp:        json.NewParser(),
 	}
 	return &fp
 }

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -13,6 +13,11 @@ import (
 // Parser is a RSS Parser
 type Parser struct{}
 
+// NewParser creates a new RSS parser
+func NewParser() *Parser {
+	return &Parser{}
+}
+
 // Parse parses an xml feed into an rss.Feed
 func (rp *Parser) Parse(feed io.Reader, opts *shared.ParseOptions) (*Feed, error) {
 	p := xpp.NewXMLPullParser(feed, false, shared.NewReaderLabel)
@@ -66,12 +71,6 @@ func (rp *Parser) parseRoot(p *xpp.XMLPullParser, opts *shared.ParseOptions) (*F
 					return nil, err
 				}
 			} else if name == "item" {
-				// Check if we've reached the MaxItems limit
-				if opts != nil && opts.MaxItems > 0 && len(items) >= opts.MaxItems {
-					p.Skip() // Skip this item
-					continue
-				}
-				
 				item, err := rp.parseItem(p)
 				if err != nil {
 					return nil, err
@@ -254,12 +253,6 @@ func (rp *Parser) parseChannel(p *xpp.XMLPullParser, opts *shared.ParseOptions) 
 				}
 				rss.SkipDays = result
 			} else if name == "item" {
-				// Check if we've reached the MaxItems limit
-				if opts != nil && opts.MaxItems > 0 && len(rss.Items) >= opts.MaxItems {
-					p.Skip() // Skip this item
-					continue
-				}
-				
 				result, err := rp.parseItem(p)
 				if err != nil {
 					return nil, err

--- a/rss/parser_test.go
+++ b/rss/parser_test.go
@@ -26,7 +26,7 @@ func TestParser_Parse(t *testing.T) {
 		f, _ := os.ReadFile(ff)
 
 		// Parse actual feed
-		fp := &rss.Parser{}
+		fp := rss.NewParser()
 		actual, _ := fp.Parse(bytes.NewReader(f), nil)
 
 		// Get json encoded expected feed result

--- a/rss/parser_test.go
+++ b/rss/parser_test.go
@@ -27,7 +27,7 @@ func TestParser_Parse(t *testing.T) {
 
 		// Parse actual feed
 		fp := &rss.Parser{}
-		actual, _ := fp.Parse(bytes.NewReader(f))
+		actual, _ := fp.Parse(bytes.NewReader(f), nil)
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("../testdata/parser/rss/%s.json", name)

--- a/translator.go
+++ b/translator.go
@@ -15,7 +15,7 @@ import (
 // Translator converts a particular feed (atom.Feed or rss.Feed of json.Feed)
 // into the generic Feed struct
 type Translator interface {
-	Translate(feed interface{}) (*Feed, error)
+	Translate(feed interface{}, opts *ParseOptions) (*Feed, error)
 }
 
 // DefaultRSSTranslator converts an rss.Feed struct
@@ -28,11 +28,12 @@ type DefaultRSSTranslator struct{}
 
 // Translate converts an RSS feed into the universal
 // feed type.
-func (t *DefaultRSSTranslator) Translate(feed interface{}) (*Feed, error) {
+func (t *DefaultRSSTranslator) Translate(feed interface{}, opts *ParseOptions) (*Feed, error) {
 	rss, found := feed.(*rss.Feed)
 	if !found {
 		return nil, fmt.Errorf("Feed did not match expected type of *rss.Feed")
 	}
+	
 
 	result := &Feed{}
 	result.Title = t.translateFeedTitle(rss)
@@ -527,11 +528,12 @@ type DefaultAtomTranslator struct{}
 
 // Translate converts an Atom feed into the universal
 // feed type.
-func (t *DefaultAtomTranslator) Translate(feed interface{}) (*Feed, error) {
+func (t *DefaultAtomTranslator) Translate(feed interface{}, opts *ParseOptions) (*Feed, error) {
 	atom, found := feed.(*atom.Feed)
 	if !found {
 		return nil, fmt.Errorf("Feed did not match expected type of *atom.Feed")
 	}
+	
 
 	result := &Feed{}
 	result.Title = t.translateFeedTitle(atom)
@@ -855,7 +857,7 @@ type DefaultJSONTranslator struct{}
 
 // Translate converts an JSON feed into the universal
 // feed type.
-func (t *DefaultJSONTranslator) Translate(feed interface{}) (*Feed, error) {
+func (t *DefaultJSONTranslator) Translate(feed interface{}, opts *ParseOptions) (*Feed, error) {
 	json, found := feed.(*json.Feed)
 	if !found {
 		return nil, fmt.Errorf("Feed did not match expected type of *json.Feed")

--- a/translator_test.go
+++ b/translator_test.go
@@ -31,8 +31,8 @@ func TestDefaultRSSTranslator_Translate(t *testing.T) {
 		// Parse actual feed
 		translator := &gofeed.DefaultRSSTranslator{}
 		fp := &rss.Parser{}
-		rssFeed, _ := fp.Parse(f)
-		actual, _ := translator.Translate(rssFeed)
+		rssFeed, _ := fp.Parse(f, nil)
+		actual, _ := translator.Translate(rssFeed, nil)
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("testdata/translator/rss/%s.json", name)
@@ -52,7 +52,7 @@ func TestDefaultRSSTranslator_Translate(t *testing.T) {
 
 func TestDefaultRSSTranslator_Translate_WrongType(t *testing.T) {
 	translator := &gofeed.DefaultRSSTranslator{}
-	af, err := translator.Translate("wrong type")
+	af, err := translator.Translate("wrong type", nil)
 	assert.Nil(t, af)
 	assert.NotNil(t, err)
 }
@@ -73,8 +73,8 @@ func TestDefaultAtomTranslator_Translate(t *testing.T) {
 		// Parse actual feed
 		translator := &gofeed.DefaultAtomTranslator{}
 		fp := &atom.Parser{}
-		atomFeed, _ := fp.Parse(f)
-		actual, _ := translator.Translate(atomFeed)
+		atomFeed, _ := fp.Parse(f, nil)
+		actual, _ := translator.Translate(atomFeed, nil)
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("testdata/translator/atom/%s.json", name)
@@ -94,7 +94,7 @@ func TestDefaultAtomTranslator_Translate(t *testing.T) {
 
 func TestDefaultAtomTranslator_Translate_WrongType(t *testing.T) {
 	translator := &gofeed.DefaultAtomTranslator{}
-	af, err := translator.Translate("wrong type")
+	af, err := translator.Translate("wrong type", nil)
 	assert.Nil(t, af)
 	assert.NotNil(t, err)
 }
@@ -119,8 +119,8 @@ func TestDefaultJSONTranslator_Translate(t *testing.T) {
 		// Parse actual feed
 		translator := &gofeed.DefaultJSONTranslator{}
 		fp := json.Parser{}
-		jsonFeed, _ := fp.Parse(f)
-		actual, _ := translator.Translate(jsonFeed)
+		jsonFeed, _ := fp.Parse(f, nil)
+		actual, _ := translator.Translate(jsonFeed, nil)
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("testdata/translator/json/%s_expected.json", name)
@@ -152,8 +152,8 @@ func TestDefaultJSONTranslator_Translate(t *testing.T) {
 	// Parse actual feed
 	translator := &gofeed.DefaultJSONTranslator{}
 	fp := json.Parser{}
-	feed, _ := fp.Parse(bytes.NewReader(f))
-	actual, _ := translator.Translate(feed)
+	feed, _ := fp.Parse(bytes.NewReader(f), nil)
+	actual, _ := translator.Translate(feed, nil)
 
 	assert.Equal(t, "title", actual.Title)
 	assert.Equal(t, "description", actual.Description)
@@ -207,8 +207,8 @@ func TestDefaultJSONTranslator_Translate(t *testing.T) {
 	f, _ = ioutil.ReadFile(ff)
 
 	// Parse actual feed
-	feed, _ = fp.Parse(bytes.NewReader(f))
-	actual, _ = translator.Translate(feed)
+	feed, _ = fp.Parse(bytes.NewReader(f), nil)
+	actual, _ = translator.Translate(feed, nil)
 
 	assert.Equal(t, "content_text", actual.Items[0].Content)
 	assert.Equal(t, "https://sample-json-feed.com/banner_image.png", actual.Items[0].Image.URL)
@@ -218,7 +218,7 @@ func TestDefaultJSONTranslator_Translate(t *testing.T) {
 
 func TestDefaultJSONTranslator_Translate_WrongType(t *testing.T) {
 	translator := &gofeed.DefaultJSONTranslator{}
-	af, err := translator.Translate("wrong type")
+	af, err := translator.Translate("wrong type", nil)
 	assert.Nil(t, af)
 	assert.NotNil(t, err)
 }

--- a/translator_test.go
+++ b/translator_test.go
@@ -30,7 +30,7 @@ func TestDefaultRSSTranslator_Translate(t *testing.T) {
 
 		// Parse actual feed
 		translator := &gofeed.DefaultRSSTranslator{}
-		fp := &rss.Parser{}
+		fp := rss.NewParser()
 		rssFeed, _ := fp.Parse(f, nil)
 		actual, _ := translator.Translate(rssFeed, nil)
 
@@ -72,7 +72,7 @@ func TestDefaultAtomTranslator_Translate(t *testing.T) {
 
 		// Parse actual feed
 		translator := &gofeed.DefaultAtomTranslator{}
-		fp := &atom.Parser{}
+		fp := atom.NewParser()
 		atomFeed, _ := fp.Parse(f, nil)
 		actual, _ := translator.Translate(atomFeed, nil)
 
@@ -118,7 +118,7 @@ func TestDefaultJSONTranslator_Translate(t *testing.T) {
 
 		// Parse actual feed
 		translator := &gofeed.DefaultJSONTranslator{}
-		fp := json.Parser{}
+		fp := json.NewParser()
 		jsonFeed, _ := fp.Parse(f, nil)
 		actual, _ := translator.Translate(jsonFeed, nil)
 
@@ -151,7 +151,7 @@ func TestDefaultJSONTranslator_Translate(t *testing.T) {
 
 	// Parse actual feed
 	translator := &gofeed.DefaultJSONTranslator{}
-	fp := json.Parser{}
+	fp := json.NewParser()
 	feed, _ := fp.Parse(bytes.NewReader(f), nil)
 	actual, _ := translator.Translate(feed, nil)
 


### PR DESCRIPTION
## Overview

Adds constructor functions for format-specific parsers as specified in #248.

## Changes

- Added `NewParser()` for RSS, Atom, and JSON parsers
- Updated universal parser to use constructors instead of struct literals
- Removed misleading MaxItems (it didn't actually save memory)

## Breaking Changes

- MaxItems removed from ParseOptions

Closes #248