### PR TITLE
chore: upgrade go version in github ci to 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.23'
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mmcdole/gofeed/v2
 
-go 1.21
+go 1.23
 
 require (
 	github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23


### PR DESCRIPTION
## Overview
Update go version in github build workflow to `1.23`