### PR TITLE
Fix name of example in parser_test.go

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -270,7 +270,7 @@ func ExampleParser_ParseString() {
 	fmt.Println(feed.Title)
 }
 
-func ExampleParserWithBasicAuth_ParseURL() {
+func ExampleParser_ParseURL_withBasicAuth() {
 	fp := gofeed.NewParser()
 	fp.AuthConfig = &gofeed.Auth{
 		Username: "foo",


### PR DESCRIPTION
With the unfixed name, `go test` complains about `ExampleParserWithBasicAuth_ParseURL refers to unknown identifier: ParserWithBasicAuth`