### PR TITLE
fix: apply correct UTC offsets for RFC 822 timezone abbreviations

### DIFF
--- a/internal/shared/dateparser.go
+++ b/internal/shared/dateparser.go
@@ -138,6 +138,23 @@ var dateFormats = []string{
 	"01-02-2006",
 }
 
+// rfc822Zones maps RFC 822 §5 timezone abbreviations to their UTC offset in
+// seconds.  Go's time.Parse recognises the abbreviation but assigns offset 0,
+// and time.LoadLocation rejects short names such as "EDT", so we need an
+// explicit table.
+var rfc822Zones = map[string]int{
+	"UT":  0, // included for completeness; offset-0 entries are no-ops in fixRFC822Zone
+	"GMT": 0,
+	"EST": -5 * 3600,
+	"EDT": -4 * 3600,
+	"CST": -6 * 3600,
+	"CDT": -5 * 3600,
+	"MST": -7 * 3600,
+	"MDT": -6 * 3600,
+	"PST": -8 * 3600,
+	"PDT": -7 * 3600,
+}
+
 // Named zone cannot be consistently loaded, so handle separately
 var dateFormatsWithNamedZone = []string{
 	"Mon, January 02, 2006, 15:04:05 MST",
@@ -187,6 +204,24 @@ var dateFormatsWithNamedZone = []string{
 	"01/02/2006 15:04:05 MST",
 }
 
+// fixRFC822Zone corrects the UTC offset when Go's time.Parse recognised a
+// named timezone abbreviation (e.g. "EDT") but assigned offset 0.  If the
+// zone name appears in the RFC 822 table the time is adjusted to the correct
+// fixed offset; otherwise t is returned unchanged.
+func fixRFC822Zone(t time.Time, format, raw string) time.Time {
+	zoneName, offset := t.Zone()
+	if offset != 0 {
+		return t
+	}
+	if correctOffset, ok := rfc822Zones[zoneName]; ok && correctOffset != 0 {
+		loc := time.FixedZone(zoneName, correctOffset)
+		if fixed, err := time.ParseInLocation(format, raw, loc); err == nil {
+			return fixed
+		}
+	}
+	return t
+}
+
 // ParseDate parses a given date string using a large
 // list of commonly found feed date formats.
 func ParseDate(ds string) (t time.Time, err error) {
@@ -196,7 +231,7 @@ func ParseDate(ds string) (t time.Time, err error) {
 	}
 	for _, f := range dateFormats {
 		if t, err = time.Parse(f, d); err == nil {
-			return
+			return fixRFC822Zone(t, f, d), nil
 		}
 	}
 	for _, f := range dateFormatsWithNamedZone {
@@ -205,8 +240,13 @@ func ParseDate(ds string) (t time.Time, err error) {
 			continue
 		}
 
-		// This is a format match! Now try to load the timezone name
-		loc, err := time.LoadLocation(t.Location().String())
+		// This is a format match! Now try to load the timezone name.
+		if fixed := fixRFC822Zone(t, f, ds); fixed != t {
+			return fixed, nil
+		}
+
+		zoneName := t.Location().String()
+		loc, err := time.LoadLocation(zoneName)
 		if err != nil {
 			// We couldn't load the TZ name. Just use UTC instead...
 			return t, nil

--- a/internal/shared/dateparser_tz_test.go
+++ b/internal/shared/dateparser_tz_test.go
@@ -1,0 +1,67 @@
+package shared
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDateRFC822Zones(t *testing.T) {
+	tests := []struct {
+		input          string
+		expectedOffset int // seconds east of UTC
+		expectedUTCHr  int // expected hour after converting to UTC
+	}{
+		{"Mon, 21 Apr 2025 06:00:00 EDT", -4 * 3600, 10},
+		{"Mon, 21 Apr 2025 06:00:00 CDT", -5 * 3600, 11},
+		{"Mon, 21 Apr 2025 06:00:00 MDT", -6 * 3600, 12},
+		{"Mon, 21 Apr 2025 06:00:00 PDT", -7 * 3600, 13},
+		{"Mon, 21 Apr 2025 06:00:00 EST", -5 * 3600, 11},
+		{"Mon, 21 Apr 2025 06:00:00 CST", -6 * 3600, 12},
+		{"Mon, 21 Apr 2025 06:00:00 MST", -7 * 3600, 13},
+		{"Mon, 21 Apr 2025 06:00:00 PST", -8 * 3600, 14},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			parsed, err := ParseDate(tt.input)
+			if err != nil {
+				t.Fatalf("ParseDate(%q) returned error: %v", tt.input, err)
+			}
+			_, offset := parsed.Zone()
+			if offset != tt.expectedOffset {
+				t.Errorf("offset: got %d, want %d", offset, tt.expectedOffset)
+			}
+			if parsed.Hour() != 6 {
+				t.Errorf("local hour: got %d, want 6", parsed.Hour())
+			}
+			if parsed.UTC().Hour() != tt.expectedUTCHr {
+				t.Errorf("UTC hour: got %d, want %d", parsed.UTC().Hour(), tt.expectedUTCHr)
+			}
+		})
+	}
+}
+
+func TestParseDateNumericOffsetUnchanged(t *testing.T) {
+	// Numeric offsets must not be affected by the RFC 822 zone fix.
+	input := "Mon, 21 Apr 2025 06:00:00 -0400"
+	parsed, err := ParseDate(input)
+	if err != nil {
+		t.Fatalf("ParseDate(%q) returned error: %v", input, err)
+	}
+	_, offset := parsed.Zone()
+	if offset != -4*3600 {
+		t.Errorf("offset: got %d, want %d", offset, -4*3600)
+	}
+}
+
+func TestParseDateGMTUnchanged(t *testing.T) {
+	// GMT should still parse as offset 0.
+	input := "Mon, 21 Apr 2025 06:00:00 GMT"
+	parsed, err := ParseDate(input)
+	if err != nil {
+		t.Fatalf("ParseDate(%q) returned error: %v", input, err)
+	}
+	if !parsed.UTC().Equal(time.Date(2025, 4, 21, 6, 0, 0, 0, time.UTC)) {
+		t.Errorf("expected 06:00 UTC, got %s", parsed.UTC())
+	}
+}


### PR DESCRIPTION
Fixes #237

**Problem:** RSS dates with named timezone abbreviations like EDT, CDT, PDT, etc. are parsed with UTC offset 0 instead of the correct offset. For example, `Mon, 21 Apr 2025 06:00:00 EDT` is treated as UTC rather than UTC-4.

This happens because Go's `time.Parse` recognises named zones but assigns offset 0, and `time.LoadLocation` rejects short abbreviation names like "EDT".

**Fix:** Add a lookup table mapping the ten RFC 822 §5 timezone abbreviations (UT, GMT, EST, EDT, CST, CDT, MST, MDT, PST, PDT) to their fixed UTC offsets. After parsing, if the zone name matches the table and the offset is 0, re-parse with `time.ParseInLocation` using the correct fixed-offset location.

**Before:**
```
ParseDate("Mon, 21 Apr 2025 06:00:00 EDT") → offset 0 (UTC)
```

**After:**
```
ParseDate("Mon, 21 Apr 2025 06:00:00 EDT") → offset -14400 (UTC-4)
```

**Validation:**
- `go test ./internal/shared/ -v` — all pass
- `go test ./rss/ ./atom/ ./json/ ./extensions/` — all pass
- New test covers all 8 non-UTC abbreviations, verifies local hour preserved and UTC hour correct
- Edge-case tests for numeric offsets and GMT confirm no regressions