### PR TITLE
Fix example name that breaks go test ./...

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -270,7 +270,7 @@ func ExampleParser_ParseString() {
 	fmt.Println(feed.Title)
 }
 
-func ExampleParserWithBasicAuth_ParseURL() {
+func ExampleParser_ParseURL_basicAuth() {
 	fp := gofeed.NewParser()
 	fp.AuthConfig = &gofeed.Auth{
 		Username: "foo",


### PR DESCRIPTION
`go test ./...` fails to compile on master:

```
parser_test.go:273: ExampleParserWithBasicAuth_ParseURL refers to unknown identifier: ParserWithBasicAuth
```

Go treats `ExampleXxx_Yyy` as an example for identifier `Xxx`. Renaming to `ExampleParser_ParseURL_basicAuth` fixes the build. No behavior change.

Closes #267.