### PR TITLE
Fix data race on Parser lazy initialization

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -52,6 +52,16 @@ type Auth struct {
 	Password string
 }
 
+// Shared defaults used when the corresponding Parser field is unset. The
+// default translators are stateless and http.Client is safe for concurrent
+// use, so single shared instances are fine and avoid per-parse allocation.
+var (
+	defaultAtomTranslator = &DefaultAtomTranslator{}
+	defaultRSSTranslator  = &DefaultRSSTranslator{}
+	defaultJSONTranslator = &DefaultJSONTranslator{}
+	defaultClient         = &http.Client{}
+)
+
 // NewParser creates a universal feed parser.
 func NewParser() *Parser {
 	fp := Parser{
@@ -172,34 +182,34 @@ func (f *Parser) parseJSONFeed(feed io.Reader) (*Feed, error) {
 	return f.jsonTrans().Translate(jf)
 }
 
+// These accessors return a shared default when the corresponding field is
+// unset. They must not write back to the Parser: doing so races when one Parser
+// is shared across goroutines (a common pattern for crawlers).
+
 func (f *Parser) atomTrans() Translator {
 	if f.AtomTranslator != nil {
 		return f.AtomTranslator
 	}
-	f.AtomTranslator = &DefaultAtomTranslator{}
-	return f.AtomTranslator
+	return defaultAtomTranslator
 }
 
 func (f *Parser) rssTrans() Translator {
 	if f.RSSTranslator != nil {
 		return f.RSSTranslator
 	}
-	f.RSSTranslator = &DefaultRSSTranslator{}
-	return f.RSSTranslator
+	return defaultRSSTranslator
 }
 
 func (f *Parser) jsonTrans() Translator {
 	if f.JSONTranslator != nil {
 		return f.JSONTranslator
 	}
-	f.JSONTranslator = &DefaultJSONTranslator{}
-	return f.JSONTranslator
+	return defaultJSONTranslator
 }
 
 func (f *Parser) httpClient() *http.Client {
 	if f.Client != nil {
 		return f.Client
 	}
-	f.Client = &http.Client{}
-	return f.Client
+	return defaultClient
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -282,3 +282,44 @@ func ExampleParser_ParseURL_basicAuth() {
 	}
 	fmt.Println(feed.Title)
 }
+
+const concurrencyFeed = `<rss version="2.0"><channel><title>t</title><item><title>i</title></item></channel></rss>`
+
+// TestParserConcurrentParseString shares one Parser across goroutines. Before
+// the lazy-init fix this races on the AtomTranslator/RSSTranslator/JSONTranslator
+// fields under -race.
+func TestParserConcurrentParseString(t *testing.T) {
+	p := gofeed.NewParser()
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := p.ParseString(concurrencyFeed); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestParserConcurrentParseURL exercises the httpClient() lazy init the same way.
+func TestParserConcurrentParseURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, concurrencyFeed)
+	}))
+	defer srv.Close()
+
+	p := gofeed.NewParser()
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := p.ParseURL(srv.URL); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
`atomTrans`/`rssTrans`/`jsonTrans`/`httpClient` wrote back to the `Parser` on first use, so sharing one `Parser` across goroutines (common for crawlers) races on those fields under `-race`.

Fix: return the defaults without storing them. The default translators are stateless and `http.Client` is safe for concurrent use, so nothing needs to be memoized on the struct. Bare `Parser{}` literals still work.

Includes a regression test that trips the race detector on the old code and passes now.

Closes #268.