### PR TITLE
JSON: tolerate off-spec field types; fix enclosure length

### DIFF
--- a/json/coerce.go
+++ b/json/coerce.go
@@ -1,0 +1,118 @@
+package json
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// The JSON Feed spec asks readers to be liberal about a few field types. An id
+// "presented as a number or other type" must be coerced to a string, and real
+// feeds also send booleans and numeric fields as strings or floats. These
+// Unmarshalers keep one off-spec field from failing the whole feed.
+//
+// Each uses the standard alias trick: a shadow type without methods decodes
+// every field normally, while the loose fields are pulled out as raw JSON and
+// coerced by hand.
+
+func (i *Item) UnmarshalJSON(data []byte) error {
+	type alias Item
+	aux := &struct {
+		ID json.RawMessage `json:"id"`
+		*alias
+	}{alias: (*alias)(i)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	i.ID = coerceString(aux.ID)
+	return nil
+}
+
+func (f *Feed) UnmarshalJSON(data []byte) error {
+	type alias Feed
+	aux := &struct {
+		Expired json.RawMessage `json:"expired"`
+		*alias
+	}{alias: (*alias)(f)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	f.Expired = coerceBool(aux.Expired)
+	return nil
+}
+
+func (a *Attachments) UnmarshalJSON(data []byte) error {
+	type alias Attachments
+	aux := &struct {
+		SizeInBytes       json.RawMessage `json:"size_in_bytes"`
+		DurationInSeconds json.RawMessage `json:"duration_in_seconds"`
+		*alias
+	}{alias: (*alias)(a)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	a.SizeInBytes = coerceInt64(aux.SizeInBytes)
+	a.DurationInSeconds = coerceInt64(aux.DurationInSeconds)
+	return nil
+}
+
+// coerceString accepts a JSON string or number and returns it as a string.
+func coerceString(raw json.RawMessage) string {
+	if isEmptyJSON(raw) {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var n json.Number
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return n.String()
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+// coerceBool accepts a JSON boolean or a "true"/"false" string.
+func coerceBool(raw json.RawMessage) bool {
+	if isEmptyJSON(raw) {
+		return false
+	}
+	var b bool
+	if err := json.Unmarshal(raw, &b); err == nil {
+		return b
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		b, _ := strconv.ParseBool(strings.TrimSpace(s))
+		return b
+	}
+	return false
+}
+
+// coerceInt64 accepts a JSON number (integer or float) or a numeric string.
+func coerceInt64(raw json.RawMessage) int64 {
+	if isEmptyJSON(raw) {
+		return 0
+	}
+	var n json.Number
+	if err := json.Unmarshal(raw, &n); err == nil {
+		if i, err := n.Int64(); err == nil {
+			return i
+		}
+		if fl, err := n.Float64(); err == nil {
+			return int64(fl)
+		}
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		if fl, err := strconv.ParseFloat(strings.TrimSpace(s), 64); err == nil {
+			return int64(fl)
+		}
+	}
+	return 0
+}
+
+func isEmptyJSON(raw json.RawMessage) bool {
+	s := strings.TrimSpace(string(raw))
+	return s == "" || s == "null"
+}

--- a/json/coerce_test.go
+++ b/json/coerce_test.go
@@ -1,0 +1,48 @@
+package json
+
+import (
+	"strings"
+	"testing"
+)
+
+func parseFeed(t *testing.T, s string) *Feed {
+	t.Helper()
+	f, err := (&Parser{}).Parse(strings.NewReader(s))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	return f
+}
+
+// A numeric id must be coerced to a string rather than failing the feed.
+func TestNumericIDCoerced(t *testing.T) {
+	f := parseFeed(t, `{"version":"https://jsonfeed.org/version/1.1","title":"t","items":[{"id":123,"content_text":"x"}]}`)
+	if len(f.Items) != 1 || f.Items[0].ID != "123" {
+		t.Fatalf("id = %q, want \"123\"", f.Items[0].ID)
+	}
+}
+
+func TestStringIDPreserved(t *testing.T) {
+	f := parseFeed(t, `{"version":"https://jsonfeed.org/version/1","title":"t","items":[{"id":"https://x/1"}]}`)
+	if f.Items[0].ID != "https://x/1" {
+		t.Fatalf("id = %q", f.Items[0].ID)
+	}
+}
+
+func TestStringExpiredCoerced(t *testing.T) {
+	f := parseFeed(t, `{"version":"https://jsonfeed.org/version/1","title":"t","expired":"true","items":[{"id":"a"}]}`)
+	if !f.Expired {
+		t.Fatal("expired string \"true\" should coerce to true")
+	}
+}
+
+func TestFloatSizeCoerced(t *testing.T) {
+	f := parseFeed(t, `{"version":"https://jsonfeed.org/version/1","title":"t","items":[{"id":"a","attachments":[{"url":"u","size_in_bytes":5000000.0,"duration_in_seconds":3600}]}]}`)
+	att := (*f.Items[0].Attachments)[0]
+	if att.SizeInBytes != 5000000 {
+		t.Fatalf("size = %d, want 5000000", att.SizeInBytes)
+	}
+	if att.DurationInSeconds != 3600 {
+		t.Fatalf("duration = %d, want 3600", att.DurationInSeconds)
+	}
+}

--- a/json/parser_test.go
+++ b/json/parser_test.go
@@ -66,7 +66,9 @@ func TestParser_ParseInvalidAndStruct(t *testing.T) {
 	// Parse actual feed
 	fp := &jsonParser.Parser{}
 	_, err := fp.Parse(bytes.NewReader(f))
-	assert.Contains(t, err.Error(), "expect }")
+	// Invalid JSON must error. Don't pin the exact message: it depends on the
+	// JSON library and changes once custom Unmarshalers are involved.
+	assert.Error(t, err)
 
 	name = "version_json_10"
 	fmt.Printf("Testing %s... ", name)

--- a/translator.go
+++ b/translator.go
@@ -1176,9 +1176,11 @@ func (t *DefaultJSONTranslator) translateItemEnclosures(jsonItem *json.Item) (en
 			e := &Enclosure{}
 			e.URL = attachment.URL
 			e.Type = attachment.MimeType
-			e.Length = fmt.Sprintf("%d", attachment.DurationInSeconds)
+			// RSS enclosure length is the size in bytes, not the duration.
+			if attachment.SizeInBytes > 0 {
+				e.Length = fmt.Sprintf("%d", attachment.SizeInBytes)
+			}
 			// Title is not defined in global enclosure
-			// SizeInBytes is not defined in global enclosure
 			enclosures = append(enclosures, e)
 		}
 	}

--- a/translator_test.go
+++ b/translator_test.go
@@ -224,3 +224,17 @@ func TestDefaultJSONTranslator_Translate_WrongType(t *testing.T) {
 	assert.Nil(t, af)
 	assert.NotNil(t, err)
 }
+
+// A JSON Feed attachment's size_in_bytes maps to the universal Enclosure.Length
+// (bytes), not its duration.
+func TestJSONAttachmentEnclosureLength(t *testing.T) {
+	in := `{"version":"https://jsonfeed.org/version/1","title":"t","items":[{"id":"a","attachments":[{"url":"u","mime_type":"audio/mpeg","size_in_bytes":5000000,"duration_in_seconds":3600}]}]}`
+	feed, err := gofeed.NewParser().ParseString(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc := feed.Items[0].Enclosures[0]
+	if enc.Length != "5000000" {
+		t.Fatalf("enclosure length = %q, want \"5000000\" (bytes, not duration)", enc.Length)
+	}
+}


### PR DESCRIPTION
Two JSON fixes (#270).

**One off-spec field no longer fails the whole feed.** The spec says a reader must coerce a numeric `id` to a string, and real feeds also send `expired` as a string and sizes as floats. Before, any of these failed the parse:

```
{"version":"https://jsonfeed.org/version/1.1","title":"t","items":[{"id":123}]}
-> json.Item.ID: ReadString: expects " or n
```

Added tolerant `UnmarshalJSON` for `Item.id` (string or number), `Feed.expired` (bool or string), and attachment `size_in_bytes`/`duration_in_seconds` (number, float, or numeric string). Well-formed feeds parse identically.

**Enclosure length fix.** `translateItemEnclosures` set `Enclosure.Length` from `DurationInSeconds`; RSS enclosure length is the size in bytes. Now uses `SizeInBytes`, and leaves it empty when no size is given instead of emitting `0`.

One existing test asserted jsoniter's exact error string for invalid JSON; relaxed it to assert an error occurred, since the message depends on the JSON library (and changes once custom Unmarshalers are involved).

Closes #270.