### PR TITLE
Remove jsoniter; use standard library encoding/json

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ fmt.Println(feed.Author) // Valentine Wiggin
 * [goxpp](https://github.com/mmcdole/goxpp) - XML Pull Parser
 * [goquery](https://github.com/PuerkitoBio/goquery) - Go jQuery-like interface
 * [testify](https://github.com/stretchr/testify) - Unit test enhancements
-* [jsoniter](https://github.com/json-iterator/go) - Faster JSON Parsing
 
 ## License
 

--- a/detector.go
+++ b/detector.go
@@ -2,10 +2,10 @@ package gofeed
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"strings"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/mmcdole/gofeed/internal/shared"
 	xpp "github.com/mmcdole/goxpp"
 )
@@ -34,7 +34,8 @@ func DetectFeedType(feed io.Reader) FeedType {
 	buffer.ReadFrom(feed)
 
 	var firstChar byte
-	loop: for {
+loop:
+	for {
 		ch, err := buffer.ReadByte()
 		if err != nil {
 			return FeedTypeUnknown
@@ -42,7 +43,7 @@ func DetectFeedType(feed io.Reader) FeedType {
 		// ignore leading whitespace & byte order marks
 		switch ch {
 		case ' ', '\r', '\n', '\t':
-		case 0xFE, 0xFF, 0x00, 0xEF, 0xBB, 0xBF:  // utf 8-16-32 bom
+		case 0xFE, 0xFF, 0x00, 0xEF, 0xBB, 0xBF: // utf 8-16-32 bom
 		default:
 			firstChar = ch
 			buffer.UnreadByte()
@@ -72,7 +73,7 @@ func DetectFeedType(feed io.Reader) FeedType {
 		}
 	} else if firstChar == '{' {
 		// Check if document is valid JSON
-		if jsoniter.Valid(buffer.Bytes()) {
+		if json.Valid(buffer.Bytes()) {
 			return FeedTypeJSON
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0
-	github.com/json-iterator/go v1.1.12
 	github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli v1.22.3
@@ -16,8 +15,6 @@ require (
 	github.com/andybalholm/cascadia v1.3.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,16 +8,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
-github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23 h1:Zr92CAlFhy2gL+V1F+EyIuzbQNbSgP4xhTODZtrXUtk=
 github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23/go.mod h1:v+25+lT2ViuQ7mVxcncQ8ch1URund48oH+jhjiwEgS8=
-github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
-github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
@@ -27,7 +19,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=

--- a/json/parser.go
+++ b/json/parser.go
@@ -2,11 +2,9 @@ package json
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
-
-	jsoniter "github.com/json-iterator/go"
 )
-
 
 // Parser is an JSON Feed Parser
 type Parser struct{}
@@ -18,10 +16,8 @@ func (ap *Parser) Parse(feed io.Reader) (*Feed, error) {
 	buffer := new(bytes.Buffer)
 	buffer.ReadFrom(feed)
 
-	j := jsoniter.ConfigCompatibleWithStandardLibrary
-	err := j.Unmarshal(buffer.Bytes(), jsonFeed)
-	if err != nil {
+	if err := json.Unmarshal(buffer.Bytes(), jsonFeed); err != nil {
 		return nil, err
 	}
-	return jsonFeed, err
+	return jsonFeed, nil
 }

--- a/json/parser_test.go
+++ b/json/parser_test.go
@@ -66,7 +66,9 @@ func TestParser_ParseInvalidAndStruct(t *testing.T) {
 	// Parse actual feed
 	fp := &jsonParser.Parser{}
 	_, err := fp.Parse(bytes.NewReader(f))
-	assert.Contains(t, err.Error(), "expect }")
+	// Invalid JSON must error. Don't pin the exact message: it depends on the
+	// JSON library and changes once custom Unmarshalers are involved.
+	assert.Error(t, err)
 
 	name = "version_json_10"
 	fmt.Printf("Testing %s... ", name)


### PR DESCRIPTION
Removes the `jsoniter` dependency in favor of the standard library `encoding/json`. The JSON path only uses `Unmarshal` and `Valid`, both drop-in, so this also drops the `modern-go/reflect2` and `modern-go/concurrent` transitive deps and the README entry. No Go version bump: plain `encoding/json`, still on 1.19.

Same change as #266 by @akfaew, redone on current master so it merges clean. #266 had gone stale: it re-did the example-name fix already landed in #267 and touched a test assertion that #279 also changes. Thanks @akfaew for the original.

The `encoding/json/v2` option (which would need Go 1.27) is a separate future decision, better as its own feedback issue than bundled here.