### PR TITLE
Resolve named timezone abbreviations in dates

### DIFF
--- a/internal/shared/dateparser.go
+++ b/internal/shared/dateparser.go
@@ -8,14 +8,14 @@ import (
 
 // DateFormats taken from github.com/mjibson/goread
 var dateFormats = []string{
-	time.RFC822,  // RSS
+	// Numeric-offset and zoneless formats only. Named-zone formats (those
+	// ending in "MST") must NOT be here: time.Parse resolves an unknown zone
+	// abbreviation to a zero offset, so a named-zone date matched here returns
+	// silently shifted. Those layouts live in dateFormatsWithNamedZone instead.
 	time.RFC822Z, // RSS
 	time.RFC3339, // Atom
-	time.UnixDate,
 	time.RubyDate,
-	time.RFC850,
 	time.RFC1123Z,
-	time.RFC1123,
 	time.ANSIC,
 	"Mon, January 2 2006 15:04:05 -0700",
 	"Mon, Jan 2 2006 15:04:05 -700",
@@ -140,6 +140,10 @@ var dateFormats = []string{
 
 // Named zone cannot be consistently loaded, so handle separately
 var dateFormatsWithNamedZone = []string{
+	time.RFC1123,  // "Mon, 02 Jan 2006 15:04:05 MST"
+	time.RFC850,   // "Monday, 02-Jan-06 15:04:05 MST"
+	time.RFC822,   // "02 Jan 06 15:04 MST"
+	time.UnixDate, // "Mon Jan _2 15:04:05 MST 2006"
 	"Mon, January 02, 2006, 15:04:05 MST",
 	"Mon, January 02, 2006 15:04:05 MST",
 	"Mon, Jan 2, 2006 15:04 MST",
@@ -187,6 +191,34 @@ var dateFormatsWithNamedZone = []string{
 	"01/02/2006 15:04:05 MST",
 }
 
+// timezoneAbbreviations maps the zone abbreviations seen in feed dates to their
+// offset in seconds. Go's time package only knows UTC and the host's local
+// zone, so it parses any other abbreviation as a zero offset (and its handling
+// of the ones it does know depends on where the code runs). We resolve them
+// ourselves for a deterministic result. A few abbreviations are genuinely
+// ambiguous (CST, BST); we use the North American / Western European reading
+// that dominates real-world feeds.
+var timezoneAbbreviations = map[string]int{
+	"UT":   0,
+	"GMT":  0,
+	"UTC":  0,
+	"EST":  -5 * 3600,
+	"EDT":  -4 * 3600,
+	"CST":  -6 * 3600,
+	"CDT":  -5 * 3600,
+	"MST":  -7 * 3600,
+	"MDT":  -6 * 3600,
+	"PST":  -8 * 3600,
+	"PDT":  -7 * 3600,
+	"WET":  0,
+	"WEST": 1 * 3600,
+	"BST":  1 * 3600,
+	"CET":  1 * 3600,
+	"CEST": 2 * 3600,
+	"EET":  2 * 3600,
+	"EEST": 3 * 3600,
+}
+
 // ParseDate parses a given date string using a large
 // list of commonly found feed date formats.
 func ParseDate(ds string) (t time.Time, err error) {
@@ -205,17 +237,18 @@ func ParseDate(ds string) (t time.Time, err error) {
 			continue
 		}
 
-		// This is a format match! Now try to load the timezone name
-		loc, err := time.LoadLocation(t.Location().String())
-		if err != nil {
-			// We couldn't load the TZ name. Just use UTC instead...
-			return t, nil
+		// time.Parse gives an unknown zone abbreviation a zero offset, and its
+		// handling of known ones is host-dependent. If we recognise the
+		// abbreviation, rebuild the time with our own offset so the result is
+		// correct and deterministic. An unrecognised abbreviation is left as
+		// parsed (best effort).
+		if name, offset := t.Zone(); name != "" {
+			if want, ok := timezoneAbbreviations[name]; ok && want != offset {
+				t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(),
+					t.Minute(), t.Second(), t.Nanosecond(), time.FixedZone(name, want))
+			}
 		}
-
-		if t, err = time.ParseInLocation(f, ds, loc); err == nil {
-			return t, nil
-		}
-		// This should not be reachable
+		return t, nil
 	}
 
 	err = fmt.Errorf("Failed to parse date: %s", ds)

--- a/internal/shared/dateparser_test.go
+++ b/internal/shared/dateparser_test.go
@@ -1,0 +1,33 @@
+package shared
+
+import "testing"
+
+// Named timezone abbreviations must resolve to the right offset, not a silent
+// zero offset (issue #237). The result is checked in UTC.
+func TestParseDateNamedZones(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantUTC string
+	}{
+		{"Mon, 02 Jan 2006 15:04:05 EST", "2006-01-02 20:04:05"},   // -5
+		{"Mon, 02 Jan 2006 15:04:05 EDT", "2006-01-02 19:04:05"},   // -4
+		{"Mon, 02 Jan 2006 15:04:05 CST", "2006-01-02 21:04:05"},   // -6
+		{"Mon, 02 Jan 2006 15:04:05 PST", "2006-01-02 23:04:05"},   // -8
+		{"Mon, 02 Jan 2006 15:04:05 PDT", "2006-01-02 22:04:05"},   // -7
+		{"Mon, 02 Jan 2006 15:04:05 CEST", "2006-01-02 13:04:05"},  // +2
+		{"Mon, 02 Jan 2006 15:04:05 GMT", "2006-01-02 15:04:05"},   // 0
+		{"Mon, 02 Jan 2006 15:04:05 UTC", "2006-01-02 15:04:05"},   // 0
+		{"Mon, 02 Jan 2006 15:04:05 -0700", "2006-01-02 22:04:05"}, // numeric still works
+		{"2006-01-02T15:04:05Z", "2006-01-02 15:04:05"},            // RFC3339 still works
+	}
+	for _, c := range cases {
+		got, err := ParseDate(c.in)
+		if err != nil {
+			t.Errorf("%q: unexpected error: %v", c.in, err)
+			continue
+		}
+		if g := got.UTC().Format("2006-01-02 15:04:05"); g != c.wantUTC {
+			t.Errorf("%q -> %s UTC, want %s", c.in, g, c.wantUTC)
+		}
+	}
+}


### PR DESCRIPTION
RSS `pubDate` commonly uses zone abbreviations like `EDT`, `PST`, `CEST`. These were parsed with a silent zero offset, shifting the time by hours.

Two causes:
- The named-zone layouts (RFC822/RFC850/RFC1123/UnixDate) sat in the first format list. `time.Parse` matched them and, since it can't resolve most abbreviations, returned a fabricated zero-offset time and returned immediately, so the named-zone fallback never ran.
- The fallback itself called `LoadLocation` on the abbreviation, which fails for DST names (`EDT`, `PDT`, ...), so it also fell back to the zero-offset time. Behavior was additionally host-dependent.

Fix: move the named-zone layouts to the dedicated list, and resolve the abbreviation from an explicit offset table with `time.FixedZone`. Deterministic and host-independent. Numeric offsets and `Z` are unaffected.

`15:04:05 EDT` now resolves to `19:04:05Z` instead of `15:04:05Z`. Ambiguous abbreviations (CST, BST) use the North American / Western European reading common in feeds.

Closes #237.