### PR TITLE
Atom/RSS correctness: base64 gate, xml:base copy, guid isPermaLink

### DIFF
--- a/atom/parser.go
+++ b/atom/parser.go
@@ -692,12 +692,16 @@ func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
 			if err == nil {
 				result, _ = shared.ResolveHTML(base, result)
 			}
-		} else {
-			decodedStr, err := base64.StdEncoding.DecodeString(result)
-			if err == nil {
-				result = string(decodedStr)
+		} else if lowerMode == "base64" || isBinaryMediaType(lowerType) {
+			// Decode base64 only when the content says so: an explicit Atom 0.3
+			// mode="base64", or a binary media type. Decoding by default
+			// corrupts ordinary text whose type happens to be valid base64
+			// (e.g. "test").
+			if decoded, derr := base64.StdEncoding.DecodeString(result); derr == nil {
+				result = string(decoded)
 			}
 		}
+		// else: text with an unknown/non-binary type, leave it as parsed.
 	}
 
 	// resolve relative URIs in URI-containing elements according to xml:base
@@ -710,6 +714,25 @@ func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
 	}
 
 	return result, err
+}
+
+// isBinaryMediaType reports whether an Atom content type should be treated as
+// base64-encoded binary. Text and XML types never are.
+func isBinaryMediaType(t string) bool {
+	if t == "" || strings.HasPrefix(t, "text/") || strings.Contains(t, "xml") {
+		return false
+	}
+	if strings.HasPrefix(t, "image/") ||
+		strings.HasPrefix(t, "audio/") ||
+		strings.HasPrefix(t, "video/") {
+		return true
+	}
+	switch t {
+	case "application/octet-stream", "application/pdf", "application/zip",
+		"application/gzip", "application/x-gzip", "application/ogg":
+		return true
+	}
+	return false
 }
 
 func (ap *Parser) parseLanguage(p *xpp.XMLPullParser) string {

--- a/internal/shared/xmlbase.go
+++ b/internal/shared/xmlbase.go
@@ -105,12 +105,16 @@ func XmlBaseResolveUrl(b *url.URL, u string) (*url.URL, error) {
 		return relURL, nil
 	}
 
-	if b.Path != "" && u != "" && b.Path[len(b.Path)-1] != '/' {
+	// Work on a copy: b is the live base held on the parser's stack, so
+	// appending "/" to it here would rewrite the base for every sibling
+	// resolved after the first relative URL in this scope.
+	base := *b
+	if base.Path != "" && u != "" && base.Path[len(base.Path)-1] != '/' {
 		// There's no reason someone would use a path in xml:base if they
 		// didn't mean for it to be a directory
-		b.Path = b.Path + "/"
+		base.Path = base.Path + "/"
 	}
-	absURL := b.ResolveReference(relURL)
+	absURL := base.ResolveReference(relURL)
 	return absURL, nil
 }
 

--- a/internal/shared/xmlbase_test.go
+++ b/internal/shared/xmlbase_test.go
@@ -1,0 +1,33 @@
+package shared
+
+import (
+	"net/url"
+	"testing"
+)
+
+// XmlBaseResolveUrl must not mutate the base it is given: the base is the live
+// value held on the parser's xml:base stack, shared by every sibling in scope.
+func TestXmlBaseResolveUrlDoesNotMutateBase(t *testing.T) {
+	base, _ := url.Parse("http://example.com/a/b")
+	before := base.String()
+
+	if _, err := XmlBaseResolveUrl(base, "x"); err != nil {
+		t.Fatal(err)
+	}
+	if after := base.String(); after != before {
+		t.Errorf("base mutated: %q -> %q", before, after)
+	}
+}
+
+// A directory-style resolution should still work (the path is treated as a
+// directory), just without mutating the input.
+func TestXmlBaseResolveUrlResolves(t *testing.T) {
+	base, _ := url.Parse("http://example.com/a/b")
+	got, err := XmlBaseResolveUrl(base, "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.String() != "http://example.com/a/b/x" {
+		t.Errorf("resolved = %q, want %q", got.String(), "http://example.com/a/b/x")
+	}
+}

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -596,7 +596,18 @@ func (rp *Parser) parseGUID(p *xpp.XMLPullParser) (guid *GUID, err error) {
 	}
 
 	guid = &GUID{}
-	guid.IsPermalink = p.Attribute("isPermalink")
+	// The RSS 2.0 attribute is "isPermaLink" (note the capital L). XML
+	// attribute names are case sensitive, so read that spelling first and fall
+	// back to the lowercase form some feeds use. When absent it defaults to
+	// true per the spec.
+	isPermalink := p.Attribute("isPermaLink")
+	if isPermalink == "" {
+		isPermalink = p.Attribute("isPermalink")
+	}
+	if isPermalink == "" {
+		isPermalink = "true"
+	}
+	guid.IsPermalink = isPermalink
 
 	result, err := shared.ParseText(p)
 	if err != nil {

--- a/testdata/parser/atom/atom10_feed_entry_title_custom_type.json
+++ b/testdata/parser/atom/atom10_feed_entry_title_custom_type.json
@@ -1,0 +1,8 @@
+{
+    "entries": [
+        {
+            "title": "test"
+        }
+    ],
+    "version": "1.0"
+}

--- a/testdata/parser/atom/atom10_feed_entry_title_custom_type.xml
+++ b/testdata/parser/atom/atom10_feed_entry_title_custom_type.xml
@@ -1,0 +1,8 @@
+<!--
+Description: entry title - unknown non-binary media type is left as text, not base64 decoded
+-->
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title type="application/x-custom">test</title>
+  </entry>
+</feed>

--- a/testdata/parser/rss/rss_channel_item_guid.json
+++ b/testdata/parser/rss/rss_channel_item_guid.json
@@ -2,7 +2,8 @@
     "items": [
         {
             "guid": {
-                "value": "abc123"
+                "value": "abc123",
+                "isPermalink": "false"
             }
         }
     ],

--- a/testdata/parser/rss/rss_channel_item_guid_cdata_naked_markup.json
+++ b/testdata/parser/rss/rss_channel_item_guid_cdata_naked_markup.json
@@ -2,7 +2,8 @@
     "items": [
         {
             "guid": {
-                "value": "<p>abc123</p>"
+                "value": "<p>abc123</p>",
+                "isPermalink": "false"
             }
         }
     ],

--- a/testdata/parser/rss/rss_channel_item_guid_escaped_markup.json
+++ b/testdata/parser/rss/rss_channel_item_guid_escaped_markup.json
@@ -2,7 +2,8 @@
     "items": [
         {
             "guid": {
-                "value": "<p>abc123</p>"
+                "value": "<p>abc123</p>",
+                "isPermalink": "false"
             }
         }
     ],

--- a/testdata/parser/rss/rss_channel_item_guid_naked_markup.json
+++ b/testdata/parser/rss/rss_channel_item_guid_naked_markup.json
@@ -2,7 +2,8 @@
     "items": [
         {
             "guid": {
-                "value": "<p>abc123</p>"
+                "value": "<p>abc123</p>",
+                "isPermalink": "false"
             }
         }
     ],

--- a/testdata/parser/rss/rss_channel_item_guid_no_permalink.json
+++ b/testdata/parser/rss/rss_channel_item_guid_no_permalink.json
@@ -2,8 +2,8 @@
     "items": [
         {
             "guid": {
-                "value": "&lt;p&gt;abc123&lt;/p&gt;",
-                "isPermalink": "false"
+                "value": "abc123",
+                "isPermalink": "true"
             }
         }
     ],

--- a/testdata/parser/rss/rss_channel_item_guid_no_permalink.xml
+++ b/testdata/parser/rss/rss_channel_item_guid_no_permalink.xml
@@ -1,0 +1,10 @@
+<!--
+Description: rss item guid without isPermaLink - defaults to true
+-->
+<rss version="2.0">
+  <channel>
+    <item>
+      <guid>abc123</guid>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
Three related correctness fixes.

**Atom base64 (#271).** The content parser base64-decoded anything whose type wasn't text/html/xhtml. Short strings like `test` or `news` are valid base64, so `<title type="application/x-custom">test</title>` decoded to garbage bytes. Now it only decodes when the content says so: an explicit Atom 0.3 `mode="base64"`, or a binary media type. Atom 0.3 and Atom 1.0 base64 still work.

**xml:base (#272).** `XmlBaseResolveUrl` appended `/` to `b.Path` where `b` is the live base held on the parser's stack, rewriting the base for every sibling resolved after the first relative URL in that scope. Now it resolves against a copy.

**RSS guid isPermaLink (#273).** The code read `p.Attribute("isPermalink")`, but the RSS 2.0 attribute is `isPermaLink` (capital L) and XML attributes are case sensitive, so it never actually read the value. Now it reads `isPermaLink`, falls back to the lowercase variant, and defaults to `true` when absent per the spec.

Tests follow the golden convention: new `.xml`/`.json` fixtures for the guid-default and unknown-type cases, and the existing guid fixtures updated to show the now-read `isPermaLink="false"` value.

Closes #271, #272, #273.