### PR TITLE
Strip illegal control characters so feeds containing them parse

### DIFF
--- a/atom/parser.go
+++ b/atom/parser.go
@@ -28,6 +28,7 @@ type Parser struct{}
 
 // Parse parses an xml feed into an atom.Feed
 func (ap *Parser) Parse(feed io.Reader) (*Feed, error) {
+	feed = shared.NewControlCharFilterReader(feed)
 	p := xpp.NewXMLPullParser(feed, false, shared.NewReaderLabel)
 
 	_, err := shared.FindRoot(p)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli v1.22.3
 	golang.org/x/net v0.4.0
-	golang.org/x/text v0.5.0
 )
 
 require (
@@ -18,5 +17,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	golang.org/x/text v0.5.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/shared/charsetconv.go
+++ b/internal/shared/charsetconv.go
@@ -13,7 +13,5 @@ func NewReaderLabel(label string, input io.Reader) (io.Reader, error) {
 		return nil, err
 	}
 
-	// Wrap the charset decoder reader with a XML sanitizer
-	//clean := NewXMLSanitizerReader(conv)
 	return conv, nil
 }

--- a/internal/shared/xmlsanitizer.go
+++ b/internal/shared/xmlsanitizer.go
@@ -1,26 +1,36 @@
 package shared
 
-import (
-	"io"
+import "io"
 
-	"golang.org/x/text/runes"
-	"golang.org/x/text/transform"
-)
+// NewControlCharFilterReader wraps r and drops the C0 control bytes that are
+// illegal in XML (bytes below 0x20 other than tab, LF, and CR). Those byte
+// values are identical across UTF-8 and the single-byte encodings feeds use,
+// and never occur inside a multi-byte UTF-8 sequence, so filtering them on the
+// raw stream is safe regardless of the declared encoding. This lets feeds with
+// stray control characters parse instead of failing outright.
+func NewControlCharFilterReader(r io.Reader) io.Reader {
+	return &controlCharFilter{r: r}
+}
 
-// NewXMLSanitizerReader creates an io.Reader that
-// wraps another io.Reader and removes illegal xml
-// characters from the io stream.
-func NewXMLSanitizerReader(xml io.Reader) io.Reader {
-	isIllegal := runes.Predicate(func() func(rune) bool {
-		return func(r rune) bool {
-			return !(r == 0x09 ||
-				r == 0x0A ||
-				r == 0x0D ||
-				r >= 0x20 && r <= 0xDF77 ||
-				r >= 0xE000 && r <= 0xFFFD ||
-				r >= 0x10000 && r <= 0x10FFFF)
+type controlCharFilter struct {
+	r io.Reader
+}
+
+func (c *controlCharFilter) Read(p []byte) (int, error) {
+	for {
+		n, err := c.r.Read(p)
+		w := 0
+		for i := 0; i < n; i++ {
+			if b := p[i]; b < 0x20 && b != 0x09 && b != 0x0A && b != 0x0D {
+				continue
+			}
+			p[w] = p[i]
+			w++
 		}
-	}())
-	t := transform.Chain(runes.Remove(isIllegal))
-	return transform.NewReader(xml, t)
+		// Avoid returning (0, nil), which is discouraged for io.Reader: if this
+		// read was entirely illegal bytes, read again.
+		if w > 0 || err != nil {
+			return w, err
+		}
+	}
 }

--- a/internal/shared/xmlsanitizer_test.go
+++ b/internal/shared/xmlsanitizer_test.go
@@ -1,0 +1,21 @@
+package shared
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestControlCharFilterReader(t *testing.T) {
+	// Illegal C0 controls (0x00, 0x08) are dropped; tab, LF, CR and normal
+	// text are kept.
+	in := "ab\x08cd\x00ef\tgh\nij\rk"
+	got, err := io.ReadAll(NewControlCharFilterReader(strings.NewReader(in)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "abcdef\tgh\nij\rk"
+	if string(got) != want {
+		t.Errorf("got %q, want %q", string(got), want)
+	}
+}

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -15,6 +15,7 @@ type Parser struct{}
 
 // Parse parses an xml feed into an rss.Feed
 func (rp *Parser) Parse(feed io.Reader) (*Feed, error) {
+	feed = shared.NewControlCharFilterReader(feed)
 	p := xpp.NewXMLPullParser(feed, false, shared.NewReaderLabel)
 
 	_, err := shared.FindRoot(p)

--- a/testdata/parser/rss/rss_channel_item_illegal_char.json
+++ b/testdata/parser/rss/rss_channel_item_illegal_char.json
@@ -1,0 +1,8 @@
+{
+    "items": [
+        {
+            "title": "abcd"
+        }
+    ],
+    "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_item_illegal_char.xml
+++ b/testdata/parser/rss/rss_channel_item_illegal_char.xml
@@ -1,0 +1,10 @@
+<!--
+Description: rss item with an illegal control character in the title
+-->
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>abcd</title>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
Feeds routinely carry C0 control characters (e.g. `U+0008`) that are illegal in XML, and Go's `encoding/xml` rejects the whole feed (#180, #206).

**Approach.** Filter the illegal C0 control bytes (`0x00-0x1F` except tab/LF/CR) from the raw stream before parsing. These are the *only* illegal XML characters that are encoding-invariant: identical across UTF-8 and every single-byte encoding feeds use, and never part of a multi-byte UTF-8 sequence. So stripping them at the raw-byte level is safe for any declared encoding, and it is the one thing that also covers UTF-8 feeds. (The existing sanitizer was wired into the charset decoder, which `encoding/xml` never invokes for UTF-8, so it could not have fixed the common case.)

**Removes the half-finished sanitizer** that caused this to linger: it was commented out, only ran on the non-UTF-8 path, and had a transposed legal-range bound (`0xDF77` for `0xD7FF`). Drops the now-unused `x/text/runes` and `x/text/transform` (`x/text` becomes indirect).

**Scope, chosen deliberately.** I measured what `encoding/xml` actually rejects. Beyond C0 controls it also rejects `U+FFFE`/`U+FFFF` and invalid UTF-8 (mojibake, truncated multibyte). Those are *not* encoding-invariant, so stripping them safely requires decoding every feed to UTF-8 first, which reworks the charset path for all feeds. Both cases already fail on master, so this is not a regression, and that decode-first hardening is tracked separately rather than bundled into a fragile area.

Tests: a unit test for the byte filter, and a golden fixture (`rss_channel_item_illegal_char`) with a stray `U+0008` that fails to parse on master and parses cleanly here.

Closes #180, #206, #274.