### PR TITLE
ParseURL: default timeout and optional response size limit

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -8,11 +8,21 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/mmcdole/gofeed/atom"
 	"github.com/mmcdole/gofeed/json"
 	"github.com/mmcdole/gofeed/rss"
 )
+
+// defaultRequestTimeout bounds ParseURL, which would otherwise use a client
+// with no timeout and hang forever on a slow or unresponsive server.
+// ParseURLWithContext callers manage their own context and are not subject to
+// this.
+const defaultRequestTimeout = 30 * time.Second
+
+// ErrResponseTooLarge is returned when a response body exceeds Parser.MaxByteSize.
+var ErrResponseTooLarge = errors.New("gofeed: response body exceeds MaxByteSize")
 
 // ErrFeedTypeNotDetected is returned when the detection system can not figure
 // out the Feed format
@@ -39,9 +49,13 @@ type Parser struct {
 	UserAgent      string
 	AuthConfig     *Auth
 	Client         *http.Client
-	rp             *rss.Parser
-	ap             *atom.Parser
-	jp             *json.Parser
+	// MaxByteSize limits how many bytes ParseURL/ParseURLWithContext will read
+	// from a response body. Zero means no limit. Exceeding it returns
+	// ErrResponseTooLarge rather than silently truncating.
+	MaxByteSize int64
+	rp          *rss.Parser
+	ap          *atom.Parser
+	jp          *json.Parser
 }
 
 // Auth is a structure allowing to
@@ -103,9 +117,12 @@ func (f *Parser) Parse(feed io.Reader) (*Feed, error) {
 }
 
 // ParseURL fetches the contents of a given url and
-// attempts to parse the response into the universal feed type.
+// attempts to parse the response into the universal feed type. It applies a
+// default request timeout; use ParseURLWithContext to control cancellation.
 func (f *Parser) ParseURL(feedURL string) (feed *Feed, err error) {
-	return f.ParseURLWithContext(feedURL, context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout)
+	defer cancel()
+	return f.ParseURLWithContext(feedURL, ctx)
 }
 
 // ParseURLWithContext fetches contents of a given url and
@@ -148,7 +165,28 @@ func (f *Parser) ParseURLWithContext(feedURL string, ctx context.Context) (feed 
 		}
 	}
 
-	return f.Parse(resp.Body)
+	var body io.Reader = resp.Body
+	if f.MaxByteSize > 0 {
+		body = &limitedReader{r: resp.Body, left: f.MaxByteSize}
+	}
+	return f.Parse(body)
+}
+
+// limitedReader returns ErrResponseTooLarge once more than the configured
+// number of bytes has been read, rather than silently truncating (which would
+// produce a corrupt partial parse).
+type limitedReader struct {
+	r    io.Reader
+	left int64
+}
+
+func (l *limitedReader) Read(p []byte) (int, error) {
+	n, err := l.r.Read(p)
+	l.left -= int64(n)
+	if l.left < 0 {
+		return n, ErrResponseTooLarge
+	}
+	return n, err
 }
 
 // ParseString parses a feed XML string and into the

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,6 +3,7 @@ package gofeed_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -322,4 +323,49 @@ func TestParserConcurrentParseURL(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestParseURLMaxByteSize(t *testing.T) {
+	big := `<rss version="2.0"><channel><title>` + strings.Repeat("x", 200000) + `</title></channel></rss>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, big)
+	}))
+	defer srv.Close()
+
+	p := gofeed.NewParser()
+
+	p.MaxByteSize = 1000
+	if _, err := p.ParseURL(srv.URL); !errors.Is(err, gofeed.ErrResponseTooLarge) {
+		t.Errorf("small limit: got %v, want ErrResponseTooLarge", err)
+	}
+
+	p.MaxByteSize = 10_000_000
+	if _, err := p.ParseURL(srv.URL); err != nil {
+		t.Errorf("large limit: unexpected error %v", err)
+	}
+
+	p.MaxByteSize = 0 // unlimited
+	if _, err := p.ParseURL(srv.URL); err != nil {
+		t.Errorf("unlimited: unexpected error %v", err)
+	}
+}
+
+// Confirms request-context cancellation works, which the default ParseURL
+// timeout relies on.
+func TestParseURLContextTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	if _, err := gofeed.NewParser().ParseURLWithContext(srv.URL, ctx); err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("did not time out promptly: %v", elapsed)
+	}
 }


### PR DESCRIPTION
`ParseURL` used a client with no timeout and `context.Background()`, so a slow or unresponsive server hangs the caller indefinitely, and there was no cap on response size (#269).

**Timeout.** `ParseURL` now applies a 30s default request timeout via context. This is the safety net for the convenience method; `ParseURLWithContext` is unchanged, since callers there already manage their own cancellation and shouldn't have a timeout imposed on top of an explicit context. Anyone wanting different behavior sets `Parser.Client` or uses `ParseURLWithContext`.

**Size limit.** New `Parser.MaxByteSize int64`, default `0` = unlimited (no behavior change). When set, a response exceeding it returns `ErrResponseTooLarge` rather than silently truncating into a corrupt partial parse. Left opt-in deliberately: a default cap risks breaking legitimately large podcast feeds, and the timeout closes the more common hang-based hole.

Tests: `MaxByteSize` over/under/unlimited against an httptest server, and a context-cancellation test confirming the mechanism the default timeout relies on.

Closes #269.