### PR TITLE
Bump goxpp to v1.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0
-	github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23
+	github.com/mmcdole/goxpp v1.2.1
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli v1.22.3
 	golang.org/x/net v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23 h1:Zr92CAlFhy2gL+V1F+EyIuzbQNbSgP4xhTODZtrXUtk=
-github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23/go.mod h1:v+25+lT2ViuQ7mVxcncQ8ch1URund48oH+jhjiwEgS8=
+github.com/mmcdole/goxpp v1.2.1 h1:237LoHhpIKIwLO27TZ5QLrVRN21/842M2DMSaZ4ngTA=
+github.com/mmcdole/goxpp v1.2.1/go.mod h1:wABIOPqKLu6wqQim/370Vaj/fsY1s+m/ytRiY1MYF7M=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=


### PR DESCRIPTION
Updates the goxpp dependency from the old pseudo-version to v1.2.1, which brings in the fixes made there:

- DecodeElement now pops the namespace scope it consumed (was leaking the decoded element's namespaces into the parent scope)
- Skip is iterative instead of recursive
- NextText uses strings.Builder
- XmlBaseResolveUrl no longer mutates the shared base

goxpp v1.2.1 is zero-dependency and declares `go 1.19`, so this does **not** change gofeed's minimum Go version (stays 1.19) and doesn't pull in any new transitive deps.