### PR TITLE
Add KeepOriginalFeed to expose the source feed

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -36,12 +36,27 @@ type Feed struct {
 	Items           []*Item                  `json:"items"`
 	FeedType        string                   `json:"feedType"`
 	FeedVersion     string                   `json:"feedVersion"`
+
+	// originalFeed holds the source *rss.Feed, *atom.Feed, or *json.Feed when
+	// the parser was configured with KeepOriginalFeed. It is unexported (and so
+	// not serialized) because it is only meaningful in-process.
+	originalFeed interface{}
 }
 
 // String returns a JSON representation of the Feed for debugging purposes.
 func (f Feed) String() string {
 	json, _ := json.MarshalIndent(f, "", "    ")
 	return string(json)
+}
+
+// OriginalFeed returns the source feed object (*rss.Feed, *atom.Feed, or
+// *json.Feed) this Feed was translated from, giving access to format-specific
+// fields not present on the universal Feed. It is only populated when the
+// parser has KeepOriginalFeed set, and returns nil otherwise. The original is
+// held in memory, not serialized, so it does not survive a Feed that has been
+// marshaled and unmarshaled.
+func (f Feed) OriginalFeed() interface{} {
+	return f.originalFeed
 }
 
 // Item is the universal Item type that atom.Entry
@@ -100,7 +115,7 @@ func (f Feed) Len() int {
 func (f Feed) Less(i, k int) bool {
 	iParsed := f.Items[i].PublishedParsed
 	kParsed := f.Items[k].PublishedParsed
-	
+
 	if iParsed == nil && kParsed == nil {
 		return false
 	}

--- a/parser.go
+++ b/parser.go
@@ -53,9 +53,13 @@ type Parser struct {
 	// from a response body. Zero means no limit. Exceeding it returns
 	// ErrResponseTooLarge rather than silently truncating.
 	MaxByteSize int64
-	rp          *rss.Parser
-	ap          *atom.Parser
-	jp          *json.Parser
+	// KeepOriginalFeed retains the source rss/atom/json feed on the result,
+	// accessible via Feed.OriginalFeed(). Off by default: keeping it holds a
+	// second copy of the feed in memory for the lifetime of the result.
+	KeepOriginalFeed bool
+	rp               *rss.Parser
+	ap               *atom.Parser
+	jp               *json.Parser
 }
 
 // Auth is a structure allowing to
@@ -200,7 +204,9 @@ func (f *Parser) parseAtomFeed(feed io.Reader) (*Feed, error) {
 	if err != nil {
 		return nil, err
 	}
-	return f.atomTrans().Translate(af)
+	result, err := f.atomTrans().Translate(af)
+	f.keepOriginal(result, af)
+	return result, err
 }
 
 func (f *Parser) parseRSSFeed(feed io.Reader) (*Feed, error) {
@@ -209,7 +215,9 @@ func (f *Parser) parseRSSFeed(feed io.Reader) (*Feed, error) {
 		return nil, err
 	}
 
-	return f.rssTrans().Translate(rf)
+	result, err := f.rssTrans().Translate(rf)
+	f.keepOriginal(result, rf)
+	return result, err
 }
 
 func (f *Parser) parseJSONFeed(feed io.Reader) (*Feed, error) {
@@ -217,7 +225,17 @@ func (f *Parser) parseJSONFeed(feed io.Reader) (*Feed, error) {
 	if err != nil {
 		return nil, err
 	}
-	return f.jsonTrans().Translate(jf)
+	result, err := f.jsonTrans().Translate(jf)
+	f.keepOriginal(result, jf)
+	return result, err
+}
+
+// keepOriginal stashes the source feed on the result when KeepOriginalFeed is
+// set. Gating here keeps the Translator interface free of parse options.
+func (f *Parser) keepOriginal(result *Feed, original interface{}) {
+	if f.KeepOriginalFeed && result != nil {
+		result.originalFeed = original
+	}
 }
 
 // These accessors return a shared default when the corresponding field is

--- a/parser_test.go
+++ b/parser_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/mmcdole/gofeed"
+	"github.com/mmcdole/gofeed/rss"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -367,5 +368,33 @@ func TestParseURLContextTimeout(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Errorf("did not time out promptly: %v", elapsed)
+	}
+}
+
+func TestParserKeepOriginalFeed(t *testing.T) {
+	const feed = `<rss version="2.0"><channel><title>t</title><item><title>i</title></item></channel></rss>`
+
+	// Off by default: OriginalFeed() is nil.
+	p := gofeed.NewParser()
+	f, err := p.ParseString(feed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.OriginalFeed() != nil {
+		t.Errorf("OriginalFeed() = %T, want nil when KeepOriginalFeed is off", f.OriginalFeed())
+	}
+
+	// On: OriginalFeed() returns the source *rss.Feed.
+	p.KeepOriginalFeed = true
+	f, err = p.ParseString(feed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig, ok := f.OriginalFeed().(*rss.Feed)
+	if !ok {
+		t.Fatalf("OriginalFeed() = %T, want *rss.Feed", f.OriginalFeed())
+	}
+	if orig.Title != "t" {
+		t.Errorf("original feed title = %q, want %q", orig.Title, "t")
 	}
 }


### PR DESCRIPTION
Adds `Parser.KeepOriginalFeed` (off by default). When set, the parser keeps the source `*rss.Feed`/`*atom.Feed`/`*json.Feed` on the result, reachable via `Feed.OriginalFeed() interface{}`, so callers can get at format-specific fields the universal `Feed` doesn't carry.

Opt-in rather than always-on: retaining the original keeps a second full copy of the feed in memory for the result's lifetime, which most callers don't need and shouldn't pay for. Gated at the parser level so the `Translator` interface stays free of parse options.

This is the `KeepOriginalFeed` item from the roadmap (#241), based on the approach @infogulch took in #235 (adjusted from always-on to opt-in for the memory reason above). Thanks @infogulch.