### PR TITLE
Resolve RSS relative URLs against xml:base

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0
-	github.com/mmcdole/goxpp v1.2.1
+	github.com/mmcdole/goxpp v1.2.2
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli v1.22.3
 	golang.org/x/net v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/mmcdole/goxpp v1.2.1 h1:237LoHhpIKIwLO27TZ5QLrVRN21/842M2DMSaZ4ngTA=
-github.com/mmcdole/goxpp v1.2.1/go.mod h1:wABIOPqKLu6wqQim/370Vaj/fsY1s+m/ytRiY1MYF7M=
+github.com/mmcdole/goxpp v1.2.2 h1:ebBx16f5wz7RBVHN+7SQC44baamX7hRmMC5iTv49t1A=
+github.com/mmcdole/goxpp v1.2.2/go.mod h1:wABIOPqKLu6wqQim/370Vaj/fsY1s+m/ytRiY1MYF7M=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=

--- a/internal/shared/parseutils.go
+++ b/internal/shared/parseutils.go
@@ -69,6 +69,19 @@ func ParseText(p *xpp.XMLPullParser) (string, error) {
 	return DecodeEntities(result)
 }
 
+// ParseTextURL is ParseText for an element whose text is a URL: it resolves the
+// value against the element's xml:base when one is in scope. The base is
+// captured before ParseText runs, because ParseText consumes the element's end
+// tag, which pops the base off the stack.
+func ParseTextURL(p *xpp.XMLPullParser) (string, error) {
+	base := p.BaseStack.Top()
+	s, err := ParseText(p)
+	if err != nil {
+		return "", err
+	}
+	return ResolveURLIfBase(base, s), nil
+}
+
 // StripCDATA removes CDATA tags from the string
 // content outside of CDATA tags is passed via DecodeEntities
 func StripCDATA(str string) string {

--- a/internal/shared/xmlbase.go
+++ b/internal/shared/xmlbase.go
@@ -118,6 +118,22 @@ func XmlBaseResolveUrl(b *url.URL, u string) (*url.URL, error) {
 	return absURL, nil
 }
 
+// ResolveURLIfBase resolves s against base when an xml:base is in scope,
+// returning s unchanged when base is nil or resolution fails. Element-content
+// URLs (e.g. an RSS <link>) don't pass through resolveAttrs, so this lets them
+// be resolved the same way attribute URLs already are. Resolving only when a
+// base is present means URLs in feeds without xml:base are never round-tripped
+// through url.Parse and so are never normalized.
+func ResolveURLIfBase(base *url.URL, s string) string {
+	if base == nil || s == "" {
+		return s
+	}
+	if abs, err := XmlBaseResolveUrl(base, s); err == nil && abs != nil {
+		return abs.String()
+	}
+	return s
+}
+
 // Transforms html by resolving any relative URIs in attributes
 // if an error occurs during parsing or serialization, then the original string
 // is returned along with the error.

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -219,7 +219,7 @@ func (rp *Parser) parseChannel(p *xpp.XMLPullParser) (rss *Feed, err error) {
 				}
 				rss.Generator = result
 			} else if name == "docs" {
-				result, err := shared.ParseText(p)
+				result, err := shared.ParseTextURL(p)
 				if err != nil {
 					return nil, err
 				}
@@ -380,7 +380,7 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 				}
 				item.Author = result
 			} else if name == "comments" {
-				result, err := shared.ParseText(p)
+				result, err := shared.ParseTextURL(p)
 				if err != nil {
 					return nil, err
 				}
@@ -466,6 +466,7 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 }
 
 func (rp *Parser) parseLink(p *xpp.XMLPullParser) (url string, err error) {
+	base := p.BaseStack.Top()
 	href := p.Attribute("href")
 	url, err = shared.ParseText(p)
 	if err != nil {
@@ -474,6 +475,7 @@ func (rp *Parser) parseLink(p *xpp.XMLPullParser) (url string, err error) {
 	if url == "" && href != "" {
 		url = href
 	}
+	url = shared.ResolveURLIfBase(base, url)
 	return url, err
 }
 
@@ -543,7 +545,7 @@ func (rp *Parser) parseImage(p *xpp.XMLPullParser) (image *Image, err error) {
 			name := strings.ToLower(p.Name)
 
 			if name == "url" {
-				result, err := shared.ParseText(p)
+				result, err := shared.ParseTextURL(p)
 				if err != nil {
 					return nil, err
 				}
@@ -555,7 +557,7 @@ func (rp *Parser) parseImage(p *xpp.XMLPullParser) (image *Image, err error) {
 				}
 				image.Title = result
 			} else if name == "link" {
-				result, err := shared.ParseText(p)
+				result, err := shared.ParseTextURL(p)
 				if err != nil {
 					return nil, err
 				}

--- a/testdata/parser/rss/rss_channel_item_xml_base.json
+++ b/testdata/parser/rss/rss_channel_item_xml_base.json
@@ -1,0 +1,19 @@
+{
+    "title": "t",
+    "docs": "http://example.org/feeds/help",
+    "image": {
+        "url": "http://example.org/feeds/logo.png",
+        "title": "x"
+    },
+    "items": [
+        {
+            "title": "i",
+            "link": "http://example.org/feeds/post/1",
+            "links": [
+                "http://example.org/feeds/post/1"
+            ],
+            "comments": "http://example.org/feeds/post/1/comments"
+        }
+    ],
+    "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_item_xml_base.xml
+++ b/testdata/parser/rss/rss_channel_item_xml_base.xml
@@ -1,0 +1,18 @@
+<!--
+Description: rss relative URLs resolved against xml:base (item link, comments, image url; image before item exercises the container-close case)
+-->
+<rss version="2.0" xml:base="http://example.org/feeds/">
+  <channel>
+    <title>t</title>
+    <docs>help</docs>
+    <image>
+      <url>logo.png</url>
+      <title>x</title>
+    </image>
+    <item>
+      <title>i</title>
+      <link>post/1</link>
+      <comments>post/1/comments</comments>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
gofeed resolves `xml:base` for Atom link hrefs (attributes), but not for RSS URLs, which live in *element content* (`<link>post/1</link>`) and so bypass the attribute resolver. Relative RSS URLs came back unresolved even under an `xml:base` scope.

This resolves them for the RSS URL-bearing elements: `<link>` (channel + item), `<comments>`, `<docs>`, and image `<url>`/`<link>`. Idiomatic approach, matching how Atom already does it: a `shared.ParseTextURL` (the URL-resolving twin of `ParseText`, capturing the base before the end tag pops it) and a `ResolveURLIfBase` that only resolves when an `xml:base` is actually in scope, so URLs in ordinary feeds are never round-tripped through `url.Parse` or normalized.

While implementing this I found and fixed a real goxpp base-stack bug (mmcdole/goxpp#24): closing an element without its own `xml:base` popped an ancestor's base, desyncing resolution for later siblings. That affected Atom too. This PR bumps goxpp to v1.2.2 with that fix. No Go-version change (stays 1.19).

xml:base is a W3C XML-level standard (applies to RSS-as-XML, and RSS 1.0/RDF uses it), and feedparser resolves it across formats, so this is a robustness/consistency gap worth closing.

Golden fixture `rss_channel_item_xml_base` (with an image before the item, exercising the container-close case) fails on the old code and passes here.

Based on the goal of #224 by @cristoper.