### PR TITLE
Promote Atom elements embedded in RSS to the universal fields

### DIFF
--- a/testdata/translator/rss/feed_item_author_-_rss_channel_item_author_atom.json
+++ b/testdata/translator/rss/feed_item_author_-_rss_channel_item_author_atom.json
@@ -1,0 +1,49 @@
+{
+    "title": "Feed Title",
+    "items": [
+        {
+            "title": "Item Title",
+            "author": {
+                "name": "John Doe",
+                "email": "john@example.com"
+            },
+            "authors": [
+                {
+                    "name": "John Doe",
+                    "email": "john@example.com"
+                }
+            ],
+            "extensions": {
+                "atom": {
+                    "author": [
+                        {
+                            "name": "author",
+                            "value": "",
+                            "attrs": {},
+                            "children": {
+                                "email": [
+                                    {
+                                        "name": "email",
+                                        "value": "john@example.com",
+                                        "attrs": {},
+                                        "children": {}
+                                    }
+                                ],
+                                "name": [
+                                    {
+                                        "name": "name",
+                                        "value": "John Doe",
+                                        "attrs": {},
+                                        "children": {}
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "feedType": "rss",
+    "feedVersion": "2.0"
+}

--- a/testdata/translator/rss/feed_item_author_-_rss_channel_item_author_atom.xml
+++ b/testdata/translator/rss/feed_item_author_-_rss_channel_item_author_atom.xml
@@ -1,0 +1,12 @@
+<!--
+Description: atom:author in an rss item is promoted to the item author
+-->
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Feed Title</title>
+    <item>
+      <title>Item Title</title>
+      <atom:author><atom:name>John Doe</atom:name><atom:email>john@example.com</atom:email></atom:author>
+    </item>
+  </channel>
+</rss>

--- a/testdata/translator/rss/feed_item_content_-_rss_channel_item_content_atom.json
+++ b/testdata/translator/rss/feed_item_content_-_rss_channel_item_content_atom.json
@@ -1,0 +1,25 @@
+{
+    "title": "Feed Title",
+    "items": [
+        {
+            "title": "Item Title",
+            "content": "\u003cp\u003eBody\u003c/p\u003e",
+            "extensions": {
+                "atom": {
+                    "content": [
+                        {
+                            "name": "content",
+                            "value": "\u003cp\u003eBody\u003c/p\u003e",
+                            "attrs": {
+                                "type": "html"
+                            },
+                            "children": {}
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "feedType": "rss",
+    "feedVersion": "2.0"
+}

--- a/testdata/translator/rss/feed_item_content_-_rss_channel_item_content_atom.xml
+++ b/testdata/translator/rss/feed_item_content_-_rss_channel_item_content_atom.xml
@@ -1,0 +1,12 @@
+<!--
+Description: atom:content in an rss item is promoted to the item content
+-->
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Feed Title</title>
+    <item>
+      <title>Item Title</title>
+      <atom:content type="html">&lt;p&gt;Body&lt;/p&gt;</atom:content>
+    </item>
+  </channel>
+</rss>

--- a/testdata/translator/rss/feed_item_published_-_rss_channel_item_published_atom.json
+++ b/testdata/translator/rss/feed_item_published_-_rss_channel_item_published_atom.json
@@ -1,0 +1,24 @@
+{
+    "title": "Feed Title",
+    "items": [
+        {
+            "title": "Item Title",
+            "published": "2019-01-02T15:04:05Z",
+            "publishedParsed": "2019-01-02T15:04:05Z",
+            "extensions": {
+                "atom": {
+                    "published": [
+                        {
+                            "name": "published",
+                            "value": "2019-01-02T15:04:05Z",
+                            "attrs": {},
+                            "children": {}
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "feedType": "rss",
+    "feedVersion": "2.0"
+}

--- a/testdata/translator/rss/feed_item_published_-_rss_channel_item_published_atom.xml
+++ b/testdata/translator/rss/feed_item_published_-_rss_channel_item_published_atom.xml
@@ -1,0 +1,12 @@
+<!--
+Description: atom:published in an rss item is promoted to the item published date
+-->
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Feed Title</title>
+    <item>
+      <title>Item Title</title>
+      <atom:published>2019-01-02T15:04:05Z</atom:published>
+    </item>
+  </channel>
+</rss>

--- a/testdata/translator/rss/feed_item_updated_-_rss_channel_item_updated_atom.json
+++ b/testdata/translator/rss/feed_item_updated_-_rss_channel_item_updated_atom.json
@@ -1,0 +1,24 @@
+{
+    "title": "Feed Title",
+    "items": [
+        {
+            "title": "Item Title",
+            "updated": "2020-01-02T15:04:05Z",
+            "updatedParsed": "2020-01-02T15:04:05Z",
+            "extensions": {
+                "atom": {
+                    "updated": [
+                        {
+                            "name": "updated",
+                            "value": "2020-01-02T15:04:05Z",
+                            "attrs": {},
+                            "children": {}
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "feedType": "rss",
+    "feedVersion": "2.0"
+}

--- a/testdata/translator/rss/feed_item_updated_-_rss_channel_item_updated_atom.xml
+++ b/testdata/translator/rss/feed_item_updated_-_rss_channel_item_updated_atom.xml
@@ -1,0 +1,12 @@
+<!--
+Description: atom:updated in an rss item is promoted to the item updated date
+-->
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Feed Title</title>
+    <item>
+      <title>Item Title</title>
+      <atom:updated>2020-01-02T15:04:05Z</atom:updated>
+    </item>
+  </channel>
+</rss>

--- a/translator.go
+++ b/translator.go
@@ -72,6 +72,8 @@ func (t *DefaultRSSTranslator) translateFeedItem(rssItem *rss.Item) (item *Item)
 	item.Links = t.translateItemLinks(rssItem)
 	item.Published = t.translateItemPublished(rssItem)
 	item.PublishedParsed = t.translateItemPublishedParsed(rssItem)
+	item.Updated = t.translateItemUpdated(rssItem)
+	item.UpdatedParsed = t.translateItemUpdatedParsed(rssItem)
 	item.Author = t.translateItemAuthor(rssItem)
 	item.Authors = t.translateItemAuthors(rssItem)
 	item.GUID = t.translateItemGUID(rssItem)
@@ -315,11 +317,17 @@ func (t *DefaultRSSTranslator) translateItemDescription(rssItem *rss.Item) (desc
 	} else if rssItem.ITunesExt != nil && rssItem.ITunesExt.Summary != "" {
 		desc = rssItem.ITunesExt.Summary
 	}
+	if desc == "" {
+		desc = t.atomExtValue(rssItem.Extensions, "summary")
+	}
 	return
 }
 
 func (t *DefaultRSSTranslator) translateItemContent(rssItem *rss.Item) (content string) {
-	return rssItem.Content
+	if rssItem.Content != "" {
+		return rssItem.Content
+	}
+	return t.atomExtValue(rssItem.Extensions, "content")
 }
 
 func (t *DefaultRSSTranslator) translateItemLink(rssItem *rss.Item) (link string) {
@@ -337,14 +345,22 @@ func (t *DefaultRSSTranslator) translateItemUpdated(rssItem *rss.Item) (updated 
 	if rssItem.DublinCoreExt != nil && rssItem.DublinCoreExt.Date != nil {
 		updated = t.firstEntry(rssItem.DublinCoreExt.Date)
 	}
+	if updated == "" {
+		updated = t.atomExtValue(rssItem.Extensions, "updated")
+	}
 	return updated
 }
 
 func (t *DefaultRSSTranslator) translateItemUpdatedParsed(rssItem *rss.Item) (updated *time.Time) {
+	updatedText := ""
 	if rssItem.DublinCoreExt != nil && rssItem.DublinCoreExt.Date != nil {
-		updatedText := t.firstEntry(rssItem.DublinCoreExt.Date)
-		updatedDate, err := shared.ParseDate(updatedText)
-		if err == nil {
+		updatedText = t.firstEntry(rssItem.DublinCoreExt.Date)
+	}
+	if updatedText == "" {
+		updatedText = t.atomExtValue(rssItem.Extensions, "updated")
+	}
+	if updatedText != "" {
+		if updatedDate, err := shared.ParseDate(updatedText); err == nil {
 			updated = &updatedDate
 		}
 	}
@@ -357,16 +373,22 @@ func (t *DefaultRSSTranslator) translateItemPublished(rssItem *rss.Item) (pubDat
 	} else if rssItem.DublinCoreExt != nil && rssItem.DublinCoreExt.Date != nil {
 		return t.firstEntry(rssItem.DublinCoreExt.Date)
 	}
-	return
+	return t.atomExtValue(rssItem.Extensions, "published")
 }
 
 func (t *DefaultRSSTranslator) translateItemPublishedParsed(rssItem *rss.Item) (pubDate *time.Time) {
 	if rssItem.PubDateParsed != nil {
 		return rssItem.PubDateParsed
-	} else if rssItem.DublinCoreExt != nil && rssItem.DublinCoreExt.Date != nil {
-		pubDateText := t.firstEntry(rssItem.DublinCoreExt.Date)
-		pubDateParsed, err := shared.ParseDate(pubDateText)
-		if err == nil {
+	}
+	pubDateText := ""
+	if rssItem.DublinCoreExt != nil && rssItem.DublinCoreExt.Date != nil {
+		pubDateText = t.firstEntry(rssItem.DublinCoreExt.Date)
+	}
+	if pubDateText == "" {
+		pubDateText = t.atomExtValue(rssItem.Extensions, "published")
+	}
+	if pubDateText != "" {
+		if pubDateParsed, err := shared.ParseDate(pubDateText); err == nil {
 			pubDate = &pubDateParsed
 		}
 	}
@@ -396,6 +418,8 @@ func (t *DefaultRSSTranslator) translateItemAuthor(rssItem *rss.Item) (author *P
 		author = &Person{}
 		author.Name = name
 		author.Email = address
+	} else if name, email := t.atomExtChild(rssItem.Extensions, "author", "name"), t.atomExtChild(rssItem.Extensions, "author", "email"); name != "" || email != "" {
+		author = &Person{Name: name, Email: email}
 	}
 	return
 }
@@ -475,6 +499,14 @@ func (t *DefaultRSSTranslator) translateItemCategories(rssItem *rss.Item) (categ
 		cats = append(cats, rssItem.DublinCoreExt.Subject...)
 	}
 
+	for _, m := range t.extensionsForKeys([]string{"atom", "atom10", "atom03"}, rssItem.Extensions) {
+		for _, c := range m["category"] {
+			if term := c.Attrs["term"]; term != "" {
+				cats = append(cats, term)
+			}
+		}
+	}
+
 	if len(cats) > 0 {
 		categories = cats
 	}
@@ -514,6 +546,32 @@ func (t *DefaultRSSTranslator) extensionsForKeys(keys []string, extensions ext.E
 		}
 	}
 	return
+}
+
+// atomExtValue returns the text of the first matching Atom element embedded in
+// an RSS feed (across the atom/atom10/atom03 namespaces), or "" if absent. This
+// promotes Atom tags in RSS to the universal fields, the same way dc:/itunes:
+// values already are.
+func (t *DefaultRSSTranslator) atomExtValue(exts ext.Extensions, name string) string {
+	for _, m := range t.extensionsForKeys([]string{"atom", "atom10", "atom03"}, exts) {
+		if es, ok := m[name]; ok && len(es) > 0 {
+			return es[0].Value
+		}
+	}
+	return ""
+}
+
+// atomExtChild returns the text of a child of the first matching Atom element
+// (e.g. author > name).
+func (t *DefaultRSSTranslator) atomExtChild(exts ext.Extensions, parent, child string) string {
+	for _, m := range t.extensionsForKeys([]string{"atom", "atom10", "atom03"}, exts) {
+		if ps, ok := m[parent]; ok && len(ps) > 0 {
+			if cs, ok := ps[0].Children[child]; ok && len(cs) > 0 {
+				return cs[0].Value
+			}
+		}
+	}
+	return ""
 }
 
 func (t *DefaultRSSTranslator) firstEntry(entries []string) (value string) {


### PR DESCRIPTION
gofeed normalizes well-known extensions in RSS to the universal fields: `dc:creator`/`itunes:author` → `Author`, `content:encoded` → `Content`, `atom:link` → `FeedLink`/`Links`. Atom's other elements were the gap: an RSS item with `atom:author` had it captured as an extension but not promoted, so `item.Author` was set for a `dc:creator` feed but nil for an `atom:author` feed carrying the same info, purely by namespace.

This promotes the well-known Atom elements in RSS to the universal fields:

| Atom-in-RSS | Universal field |
|---|---|
| `atom:author` (name/email) | `Author`/`Authors` |
| `atom:updated` | `Updated`/`UpdatedParsed` |
| `atom:published` | `Published`/`PublishedParsed` |
| `atom:content` | `Content` |
| `atom:summary` | `Description` |
| `atom:category` | `Categories` |

Native RSS values keep precedence; Atom fills in when the native field is absent. Implemented in the translator by reading the already-captured extension tree (two small helpers, matching the `dc:`/`itunes:` pattern) rather than re-running the Atom parser. Also wires `item.Updated` for the RSS translator, which was defined but never called (no existing golden tests changed).

Tests follow the golden convention: four `testdata/translator/rss/` fixtures that fail on the old code and pass here.

Closes #291. This is the idiomatic, much smaller replacement for #153 by @Necoro, who identified the gap.