### PR TITLE
Add DublinCore extension tests and expand date parser tests

### DIFF
--- a/extensions/extensions_test.go
+++ b/extensions/extensions_test.go
@@ -45,7 +45,6 @@ func TestITunes_Extensions(t *testing.T) {
 	}
 }
 
-
 func TestMedia_Extensions(t *testing.T) {
 	files, _ := filepath.Glob("../testdata/extensions/media/*.xml")
 	for _, f := range files {
@@ -64,6 +63,38 @@ func TestMedia_Extensions(t *testing.T) {
 
 		// Get json encoded expected feed result
 		ef := fmt.Sprintf("../testdata/extensions/media/%s.json", name)
+		e, _ := os.ReadFile(ef)
+
+		// Unmarshal expected feed
+		expected := &gofeed.Feed{}
+		json.Unmarshal(e, &expected)
+
+		if assert.Equal(t, expected, actual, "Feed file %s.xml did not match expected output %s.json", name, name) {
+			fmt.Printf("OK\n")
+		} else {
+			fmt.Printf("Failed\n")
+		}
+	}
+}
+
+func TestDublinCore_Extensions(t *testing.T) {
+	files, _ := filepath.Glob("../testdata/extensions/dublincore/*.xml")
+	for _, f := range files {
+		base := filepath.Base(f)
+		name := strings.TrimSuffix(base, filepath.Ext(base))
+
+		fmt.Printf("Testing %s... ", name)
+
+		// Get actual source feed
+		ff := fmt.Sprintf("../testdata/extensions/dublincore/%s.xml", name)
+		f, _ := os.ReadFile(ff)
+
+		// Parse actual feed
+		fp := gofeed.NewParser()
+		actual, _ := fp.Parse(bytes.NewReader(f))
+
+		// Get json encoded expected feed result
+		ef := fmt.Sprintf("../testdata/extensions/dublincore/%s.json", name)
 		e, _ := os.ReadFile(ef)
 
 		// Unmarshal expected feed

--- a/internal/shared/dateparser_test.go
+++ b/internal/shared/dateparser_test.go
@@ -31,3 +31,31 @@ func TestParseDateNamedZones(t *testing.T) {
 		}
 	}
 }
+
+// A representative sample of the supported layouts must parse to the correct
+// instant, across weekday/no-weekday, offset/no-zone, fractional seconds and
+// date-only forms. Result checked in UTC (issue #119).
+func TestParseDateFormats(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantUTC string
+	}{
+		{"Mon, 02 Jan 2006 15:04:05 -0700", "2006-01-02 22:04:05"}, // RFC1123Z
+		{"Mon, 2 Jan 2006 15:04:05 -0700", "2006-01-02 22:04:05"},  // single-digit day
+		{"02 Jan 2006 15:04:05 -0700", "2006-01-02 22:04:05"},      // RFC822Z, no weekday
+		{"2006-01-02T15:04:05-07:00", "2006-01-02 22:04:05"},       // RFC3339 offset
+		{"2006-01-02T15:04:05.500Z", "2006-01-02 15:04:05"},        // fractional seconds
+		{"2006-01-02 15:04:05", "2006-01-02 15:04:05"},             // space separator, no zone
+		{"2006-01-02", "2006-01-02 00:00:00"},                      // date only
+	}
+	for _, c := range cases {
+		got, err := ParseDate(c.in)
+		if err != nil {
+			t.Errorf("%q: unexpected error: %v", c.in, err)
+			continue
+		}
+		if g := got.UTC().Format("2006-01-02 15:04:05"); g != c.wantUTC {
+			t.Errorf("%q -> %s UTC, want %s", c.in, g, c.wantUTC)
+		}
+	}
+}

--- a/testdata/extensions/dublincore/dublincore_channel_fields.json
+++ b/testdata/extensions/dublincore/dublincore_channel_fields.json
@@ -1,0 +1,93 @@
+{
+    "title": "Feed Title",
+    "updated": "2006-01-02T15:04:05Z",
+    "updatedParsed": "2006-01-02T15:04:05Z",
+    "author": {
+        "name": "Jane Doe"
+    },
+    "authors": [
+        {
+            "name": "Jane Doe"
+        }
+    ],
+    "language": "en-us",
+    "copyright": "Copyright 2006 Example",
+    "categories": [
+        "Technology"
+    ],
+    "dcExt": {
+        "creator": [
+            "Jane Doe"
+        ],
+        "subject": [
+            "Technology"
+        ],
+        "publisher": [
+            "Example Publisher"
+        ],
+        "date": [
+            "2006-01-02T15:04:05Z"
+        ],
+        "language": [
+            "en-us"
+        ],
+        "rights": [
+            "Copyright 2006 Example"
+        ]
+    },
+    "extensions": {
+        "dc": {
+            "creator": [
+                {
+                    "name": "creator",
+                    "value": "Jane Doe",
+                    "attrs": {},
+                    "children": {}
+                }
+            ],
+            "date": [
+                {
+                    "name": "date",
+                    "value": "2006-01-02T15:04:05Z",
+                    "attrs": {},
+                    "children": {}
+                }
+            ],
+            "language": [
+                {
+                    "name": "language",
+                    "value": "en-us",
+                    "attrs": {},
+                    "children": {}
+                }
+            ],
+            "publisher": [
+                {
+                    "name": "publisher",
+                    "value": "Example Publisher",
+                    "attrs": {},
+                    "children": {}
+                }
+            ],
+            "rights": [
+                {
+                    "name": "rights",
+                    "value": "Copyright 2006 Example",
+                    "attrs": {},
+                    "children": {}
+                }
+            ],
+            "subject": [
+                {
+                    "name": "subject",
+                    "value": "Technology",
+                    "attrs": {},
+                    "children": {}
+                }
+            ]
+        }
+    },
+    "items": [],
+    "feedType": "rss",
+    "feedVersion": "2.0"
+}

--- a/testdata/extensions/dublincore/dublincore_channel_fields.xml
+++ b/testdata/extensions/dublincore/dublincore_channel_fields.xml
@@ -1,0 +1,14 @@
+<!--
+Description: rss channel dublin core extension fields
+-->
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Feed Title</title>
+    <dc:creator>Jane Doe</dc:creator>
+    <dc:subject>Technology</dc:subject>
+    <dc:publisher>Example Publisher</dc:publisher>
+    <dc:date>2006-01-02T15:04:05Z</dc:date>
+    <dc:language>en-us</dc:language>
+    <dc:rights>Copyright 2006 Example</dc:rights>
+  </channel>
+</rss>

--- a/testdata/extensions/dublincore/dublincore_item_fields.json
+++ b/testdata/extensions/dublincore/dublincore_item_fields.json
@@ -1,0 +1,87 @@
+{
+    "title": "Feed Title",
+    "items": [
+        {
+            "title": "Item Title",
+            "description": "An item description",
+            "updated": "2007-02-03T10:20:30Z",
+            "updatedParsed": "2007-02-03T10:20:30Z",
+            "published": "2007-02-03T10:20:30Z",
+            "publishedParsed": "2007-02-03T10:20:30Z",
+            "author": {
+                "name": "John Smith"
+            },
+            "authors": [
+                {
+                    "name": "John Smith"
+                }
+            ],
+            "categories": [
+                "Programming"
+            ],
+            "dcExt": {
+                "creator": [
+                    "John Smith"
+                ],
+                "subject": [
+                    "Programming"
+                ],
+                "description": [
+                    "An item description"
+                ],
+                "date": [
+                    "2007-02-03T10:20:30Z"
+                ],
+                "identifier": [
+                    "urn:uuid:1234"
+                ]
+            },
+            "extensions": {
+                "dc": {
+                    "creator": [
+                        {
+                            "name": "creator",
+                            "value": "John Smith",
+                            "attrs": {},
+                            "children": {}
+                        }
+                    ],
+                    "date": [
+                        {
+                            "name": "date",
+                            "value": "2007-02-03T10:20:30Z",
+                            "attrs": {},
+                            "children": {}
+                        }
+                    ],
+                    "description": [
+                        {
+                            "name": "description",
+                            "value": "An item description",
+                            "attrs": {},
+                            "children": {}
+                        }
+                    ],
+                    "identifier": [
+                        {
+                            "name": "identifier",
+                            "value": "urn:uuid:1234",
+                            "attrs": {},
+                            "children": {}
+                        }
+                    ],
+                    "subject": [
+                        {
+                            "name": "subject",
+                            "value": "Programming",
+                            "attrs": {},
+                            "children": {}
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "feedType": "rss",
+    "feedVersion": "2.0"
+}

--- a/testdata/extensions/dublincore/dublincore_item_fields.xml
+++ b/testdata/extensions/dublincore/dublincore_item_fields.xml
@@ -1,0 +1,16 @@
+<!--
+Description: rss item dublin core extension fields
+-->
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Feed Title</title>
+    <item>
+      <title>Item Title</title>
+      <dc:creator>John Smith</dc:creator>
+      <dc:subject>Programming</dc:subject>
+      <dc:date>2007-02-03T10:20:30Z</dc:date>
+      <dc:description>An item description</dc:description>
+      <dc:identifier>urn:uuid:1234</dc:identifier>
+    </item>
+  </channel>
+</rss>

--- a/testdata/extensions/dublincore/dublincore_item_multiple_values.json
+++ b/testdata/extensions/dublincore/dublincore_item_multiple_values.json
@@ -1,0 +1,64 @@
+{
+    "title": "Feed Title",
+    "items": [
+        {
+            "title": "Item Title",
+            "author": {
+                "name": "Alice"
+            },
+            "authors": [
+                {
+                    "name": "Alice"
+                }
+            ],
+            "categories": [
+                "One",
+                "Two"
+            ],
+            "dcExt": {
+                "creator": [
+                    "Alice",
+                    "Bob"
+                ],
+                "subject": [
+                    "One",
+                    "Two"
+                ]
+            },
+            "extensions": {
+                "dc": {
+                    "creator": [
+                        {
+                            "name": "creator",
+                            "value": "Alice",
+                            "attrs": {},
+                            "children": {}
+                        },
+                        {
+                            "name": "creator",
+                            "value": "Bob",
+                            "attrs": {},
+                            "children": {}
+                        }
+                    ],
+                    "subject": [
+                        {
+                            "name": "subject",
+                            "value": "One",
+                            "attrs": {},
+                            "children": {}
+                        },
+                        {
+                            "name": "subject",
+                            "value": "Two",
+                            "attrs": {},
+                            "children": {}
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "feedType": "rss",
+    "feedVersion": "2.0"
+}

--- a/testdata/extensions/dublincore/dublincore_item_multiple_values.xml
+++ b/testdata/extensions/dublincore/dublincore_item_multiple_values.xml
@@ -1,0 +1,15 @@
+<!--
+Description: rss item dublin core with multiple values for a field
+-->
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Feed Title</title>
+    <item>
+      <title>Item Title</title>
+      <dc:creator>Alice</dc:creator>
+      <dc:creator>Bob</dc:creator>
+      <dc:subject>One</dc:subject>
+      <dc:subject>Two</dc:subject>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
Two long-standing test gaps.

**DublinCore (#8):** iTunes and Media each have a golden-fixture extension test, but DublinCore had none, and `NewDublinCoreExtension` was at 0% coverage. Adds `TestDublinCore_Extensions` with three fixtures under `testdata/extensions/dublincore` (channel fields, item fields, multiple values per field), following the exact iTunes/Media pattern. Coverage of `NewDublinCoreExtension` goes to 100%.

**Dates (#119):** date parsing was only tested for named zones. Adds `TestParseDateFormats`, a table covering representative layouts (RFC1123Z, RFC822Z without weekday, RFC3339 offset, fractional seconds, space-separated without zone, date-only). All pass against the current parser, so this locks in behavior and lifts coverage.

Tests only, no production changes.

Closes #8. Closes #119.