### PR TITLE
Fix StripCDATA dropping text before/between CDATA sections

### DIFF
--- a/internal/shared/parseutils.go
+++ b/internal/shared/parseutils.go
@@ -99,17 +99,29 @@ func StripCDATA(str string) string {
 			return buf.String()
 		}
 
-		end := indexAt(str, CDATA_END, start)
+		// Character data before the CDATA section is still character data:
+		// entity-decode it and keep it. Dropping it silently loses any text
+		// that precedes or sits between CDATA sections.
+		dec, _ := DecodeEntities(str[curr:start])
+		buf.Write([]byte(dec))
+
+		end := indexAt(str, CDATA_END, start+len(CDATA_START))
 
 		if end == -1 {
-			dec, _ := DecodeEntities(str[curr:])
+			// Unterminated CDATA (malformed; encoding/xml would have rejected
+			// it before this point). Keep the remainder, marker and all, rather
+			// than guess where the section was meant to end.
+			dec, _ := DecodeEntities(str[start:])
 			buf.Write([]byte(dec))
 			return buf.String()
 		}
 
+		// CDATA content is taken verbatim (no entity decoding).
 		buf.Write([]byte(str[start+len(CDATA_START) : end]))
 
-		curr = curr + end + len(CDATA_END)
+		// end is an absolute index; advance past the closing ]]> without
+		// re-adding curr (doing so overshoots and drops trailing content).
+		curr = end + len(CDATA_END)
 	}
 
 	return buf.String()

--- a/internal/shared/parseutils_test.go
+++ b/internal/shared/parseutils_test.go
@@ -51,6 +51,17 @@ func TestStripCDATA(t *testing.T) {
 		{"]]>", "]]>"},
 		{"<![CDATA[", "<![CDATA["},
 		{"<![CDATA[testtest", "<![CDATA[testtest"},
+
+		// Mixed text and CDATA: character data before or between CDATA
+		// sections is still character data and must be kept. These were
+		// silently dropped before (see #140).
+		{"before<![CDATA[mid]]>", "beforemid"},
+		{"A<![CDATA[B]]>C", "ABC"},
+		{"<![CDATA[A]]>MID<![CDATA[B]]>", "AMIDB"},
+		{"a<![CDATA[b]]>c<![CDATA[d]]>e", "abcde"},
+		{"&lt;p&gt;<![CDATA[<b>]]>", "<p><b>"},
+		{"x<![CDATA[]]>y", "xy"},
+		{"Breaking: <![CDATA[Big News]]>", "Breaking: Big News"},
 		{`<![CDATA[
     Since this is a CDATA section
     I can use all sorts of reserved characters

--- a/testdata/parser/rss/rss_channel_item_description_mixed_cdata.json
+++ b/testdata/parser/rss/rss_channel_item_description_mixed_cdata.json
@@ -1,0 +1,10 @@
+{
+    "title": "t",
+    "items": [
+        {
+            "title": "i",
+            "description": "Breaking: \u003cb\u003eBig News\u003c/b\u003e today"
+        }
+    ],
+    "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_item_description_mixed_cdata.xml
+++ b/testdata/parser/rss/rss_channel_item_description_mixed_cdata.xml
@@ -1,0 +1,12 @@
+<!--
+Description: rss item description mixing text and a CDATA section - text before the CDATA must be kept (#140)
+-->
+<rss version="2.0">
+  <channel>
+    <title>t</title>
+    <item>
+      <title>i</title>
+      <description>Breaking: <![CDATA[<b>Big News</b>]]> today</description>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
`StripCDATA` walked the string writing each CDATA section's content but never wrote the character data *between* the cursor and the next CDATA start, and advanced the cursor with `curr = curr + end + len(CDATA_END)` where `end` is already absolute. Result: any text before or between CDATA sections was silently dropped, and trailing text after multiple sections was lost.

```
before<![CDATA[mid]]>            -> "mid"        (want "beforemid")
A<![CDATA[B]]>C                  -> "BC"         (want "ABC")
a<![CDATA[b]]>c<![CDATA[d]]>e    -> "bd"         (want "abcde")
Breaking: <![CDATA[Big News]]>   -> "Big News"   (want "Breaking: Big News")
```

Fix: emit the entity-decoded character data before each CDATA section, and advance the cursor to just past the closing `]]>`. Unterminated-CDATA handling is unchanged. Raw-HTML-in-description (the reason gofeed uses `innerxml` here) is unaffected.

Adds the mixed-content cases to `TestStripCDATA` and an end-to-end `rss_channel_item_description_mixed_cdata` golden fixture; both fail on the old code.

Fixes #140. This is the targeted content-loss fix. The broader "parse all non-schema content into one arbitrary-element tree" rework (#276) is a separate, larger effort and doesn't change that this `innerxml`-based path stays correct for HTML-bearing text fields.