### PR TITLE
Remove Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gofeed
 
-[![CI](https://github.com/mmcdole/gofeed/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/mmcdole/gofeed/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/mmcdole/gofeed/branch/master/graph/badge.svg)](https://codecov.io/gh/mmcdole/gofeed) [![Go Report Card](https://goreportcard.com/badge/github.com/mmcdole/gofeed)](https://goreportcard.com/report/github.com/mmcdole/gofeed) [![Go Reference](https://pkg.go.dev/badge/github.com/mmcdole/gofeed.svg)](https://pkg.go.dev/github.com/mmcdole/gofeed) [![License](http://img.shields.io/:license-mit-blue.svg)](http://doge.mit-license.org)
+[![CI](https://github.com/mmcdole/gofeed/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/mmcdole/gofeed/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/mmcdole/gofeed/branch/master/graph/badge.svg)](https://codecov.io/gh/mmcdole/gofeed) [![Go Reference](https://pkg.go.dev/badge/github.com/mmcdole/gofeed.svg)](https://pkg.go.dev/github.com/mmcdole/gofeed) [![License](http://img.shields.io/:license-mit-blue.svg)](http://doge.mit-license.org)
 
 # Gofeed: A Robust Feed Parser for Golang
 


### PR DESCRIPTION
goreportcard.com was retired and the gojp/goreportcard repo archived on July 1, 2026. The badge URL still serves a cached image, so it looks alive, but it will never update again.