### PR TITLE
Treat non-content <encoded> items as custom elements instead of failing the feed

### DIFF
--- a/rss/parser.go
+++ b/rss/parser.go
@@ -356,16 +356,13 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 					return nil, err
 				}
 				item.Description = result
-			} else if name == "encoded" {
-				space := strings.TrimSpace(p.Space)
-				prefix := shared.PrefixForNamespace(space, p)
-				if prefix == "content" {
-					result, err := shared.ParseText(p)
-					if err != nil {
-						return nil, err
-					}
-					item.Content = result
+			} else if name == "encoded" &&
+				shared.PrefixForNamespace(strings.TrimSpace(p.Space), p) == "content" {
+				result, err := shared.ParseText(p)
+				if err != nil {
+					return nil, err
 				}
+				item.Content = result
 			} else if name == "link" {
 				result, err := rp.parseLink(p)
 				if err != nil {

--- a/testdata/parser/rss/issue_303_encoded_no_namespace.json
+++ b/testdata/parser/rss/issue_303_encoded_no_namespace.json
@@ -1,0 +1,11 @@
+{
+  "items": [
+    {
+      "title": "First",
+      "custom": {
+        "encoded": "hello"
+      }
+    }
+  ],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/issue_303_encoded_no_namespace.xml
+++ b/testdata/parser/rss/issue_303_encoded_no_namespace.xml
@@ -1,0 +1,12 @@
+<!--
+Description: an <encoded> element without the content: namespace must not
+abort the parse; it is treated as a custom element (issue #303)
+-->
+<rss version="2.0">
+  <channel>
+    <item>
+      <encoded>hello</encoded>
+      <title>First</title>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
Fixes #303.

The `name == "encoded"` branch in `parseItem` only consumed the element when its prefix resolved to `content`. For an unprefixed `<encoded>` (or one on the `rss`/`rdf` prefixes, which `IsExtension` exempts), the branch matched but neither parsed nor skipped the element. The item loop then descended into the element's children, treated `</encoded>` as the item's end tag, and the trailing `Expect(EndTag, "item")` failed the whole feed, dropping items that had already parsed.

The fix folds the prefix check into the branch condition, so any non-content `<encoded>` falls through the ladder to the custom-field handler like every other unknown element. It ends up in `item.Custom["encoded"]` rather than being promoted to `Content`, since guessing that the author meant `content:encoded` seemed wrong.

`content:encoded` handling is unchanged and still covered by `rss_channel_item_content_encoded`.

Test: new `issue_303_encoded_no_namespace` testdata pair. It fails on master (the parse returns an error and a nil feed) and passes with this change.