### PR TITLE
Skip <cloud> children instead of failing the feed

### DIFF
--- a/rss/parser.go
+++ b/rss/parser.go
@@ -788,7 +788,12 @@ func (rp *Parser) parseCloud(p *xpp.XMLPullParser) (*Cloud, error) {
 	cloud.RegisterProcedure = p.Attribute("registerProcedure")
 	cloud.Protocol = p.Attribute("protocol")
 
-	shared.NextTag(p)
+	// The spec defines <cloud> as an empty element, but feeds exist with text
+	// or child elements inside it. Skip to the matching end tag rather than
+	// assuming the next tag is it.
+	if err := p.Skip(); err != nil {
+		return nil, err
+	}
 
 	if err := p.Expect(xpp.EndTag, "cloud"); err != nil {
 		return nil, err

--- a/rss/parser_test.go
+++ b/rss/parser_test.go
@@ -45,4 +45,13 @@ func TestParser_Parse(t *testing.T) {
 	}
 }
 
+func TestParser_Parse_CloudTruncated(t *testing.T) {
+	// A stream that ends inside <cloud> must surface the underlying XML
+	// error from the skip to the matching end tag.
+	feed := `<rss version="2.0"><channel><cloud domain="x"><child>`
+	fp := &rss.Parser{}
+	_, err := fp.Parse(strings.NewReader(feed))
+	assert.Error(t, err)
+}
+
 // TODO: Examples

--- a/testdata/parser/rss/issue_304_cloud_with_children.json
+++ b/testdata/parser/rss/issue_304_cloud_with_children.json
@@ -1,0 +1,12 @@
+{
+  "title": "Sample Feed",
+  "cloud": {
+    "domain": "rpc.sys.com",
+    "port": "80",
+    "path": "/RPC2",
+    "registerProcedure": "myCloud.rssPleaseNotify",
+    "protocol": "xml-rpc"
+  },
+  "items": [],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/issue_304_cloud_with_children.xml
+++ b/testdata/parser/rss/issue_304_cloud_with_children.xml
@@ -1,0 +1,10 @@
+<!--
+Description: a <cloud> element with child elements must not abort the
+parse; children are skipped and the attributes kept (issue #304)
+-->
+<rss version="2.0">
+  <channel>
+    <cloud domain="rpc.sys.com" port="80" path="/RPC2" registerProcedure="myCloud.rssPleaseNotify" protocol="xml-rpc"><child>x</child></cloud>
+    <title>Sample Feed</title>
+  </channel>
+</rss>


### PR DESCRIPTION
Fixes #304.

`parseCloud` read the attributes, called `shared.NextTag` once (discarding the error), and immediately expected `EndTag "cloud"`. That works for `<cloud/>` and `<cloud>text</cloud>`, but a `<cloud>` containing a child element left the parser on the child's start tag, so the Expect error propagated out of `parseChannel` and the whole feed was lost.

Per the RSS 2.0 spec `<cloud>` is an empty element, but every other off-spec shape in this parser is tolerated, and this was the one channel child where malformed input was fatal. The fix replaces the single `NextTag` with `p.Skip()`, which consumes everything up to the matching end tag and returns its error. Attributes are unchanged; they are the only data the spec defines for `<cloud>`.

Test: new `issue_304_cloud_with_children` testdata pair. It fails on master (parse error, nil feed) and passes with this change.