### PR TITLE
Keep decoding entities after a bare ampersand

### DIFF
--- a/atom/parser.go
+++ b/atom/parser.go
@@ -683,16 +683,14 @@ func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
 		if lowerType == "text" ||
 			strings.HasPrefix(lowerType, "text/") ||
 			(lowerType == "" && lowerMode == "") {
-			result, err = shared.DecodeEntities(result)
+			result = shared.DecodeEntities(result)
 		} else if strings.Contains(lowerType, "xhtml") {
 			result = ap.stripWrappingDiv(result)
 			result, _ = shared.ResolveHTML(base, result)
 		} else if lowerType == "html" {
 			result = ap.stripWrappingDiv(result)
-			result, err = shared.DecodeEntities(result)
-			if err == nil {
-				result, _ = shared.ResolveHTML(base, result)
-			}
+			result = shared.DecodeEntities(result)
+			result, _ = shared.ResolveHTML(base, result)
 		} else if lowerMode == "base64" || isBinaryMediaType(lowerType) {
 			// Decode base64 only when the content says so: an explicit Atom 0.3
 			// mode="base64", or a binary media type. Decoding by default

--- a/internal/shared/parseutils.go
+++ b/internal/shared/parseutils.go
@@ -2,7 +2,6 @@ package shared
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"html"
 	"regexp"
@@ -16,9 +15,6 @@ var (
 	nameEmailRgx = regexp.MustCompile(`^([^@]+)\s+\(([^@]+@[^)]+)\)$`)
 	nameOnlyRgx  = regexp.MustCompile(`^([^@()]+)$`)
 	emailOnlyRgx = regexp.MustCompile(`^([^@()]+@[^@()]+)$`)
-
-	ErrTruncatedEntity         = errors.New("truncated entity")
-	ErrInvalidNumericReference = errors.New("invalid numeric reference")
 )
 
 const CDATA_START = "<![CDATA["
@@ -66,7 +62,7 @@ func ParseText(p *xpp.XMLPullParser) (string, error) {
 		return StripCDATA(result), nil
 	}
 
-	return DecodeEntities(result)
+	return DecodeEntities(result), nil
 }
 
 // ParseTextURL is ParseText for an element whose text is a URL: it resolves the
@@ -94,7 +90,7 @@ func StripCDATA(str string) string {
 		start := indexAt(str, CDATA_START, curr)
 
 		if start == -1 {
-			dec, _ := DecodeEntities(str[curr:])
+			dec := DecodeEntities(str[curr:])
 			buf.Write([]byte(dec))
 			return buf.String()
 		}
@@ -102,7 +98,7 @@ func StripCDATA(str string) string {
 		// Character data before the CDATA section is still character data:
 		// entity-decode it and keep it. Dropping it silently loses any text
 		// that precedes or sits between CDATA sections.
-		dec, _ := DecodeEntities(str[curr:start])
+		dec := DecodeEntities(str[curr:start])
 		buf.Write([]byte(dec))
 
 		end := indexAt(str, CDATA_END, start+len(CDATA_START))
@@ -111,7 +107,7 @@ func StripCDATA(str string) string {
 			// Unterminated CDATA (malformed; encoding/xml would have rejected
 			// it before this point). Keep the remainder, marker and all, rather
 			// than guess where the section was meant to end.
-			dec, _ := DecodeEntities(str[start:])
+			dec := DecodeEntities(str[start:])
 			buf.Write([]byte(dec))
 			return buf.String()
 		}
@@ -127,14 +123,24 @@ func StripCDATA(str string) string {
 	return buf.String()
 }
 
+// maxEntityLen bounds how far past an '&' the terminating ';' may be. The
+// longest named HTML entity is 33 bytes with delimiters
+// ("&CounterClockwiseContourIntegral;"); 64 leaves margin without letting a
+// distant stray ';' make the scan quadratic on ampersand-heavy text.
+const maxEntityLen = 64
+
 // DecodeEntities decodes escaped XML entities
 // in a string and returns the unescaped string
-func DecodeEntities(str string) (string, error) {
+func DecodeEntities(str string) string {
+	idx := strings.IndexByte(str, '&')
+	if idx == -1 {
+		return str
+	}
+
+	var buf bytes.Buffer
 	data := []byte(str)
-	buf := bytes.NewBuffer([]byte{})
 
 	for len(data) > 0 {
-		// Find the next entity
 		idx := bytes.IndexByte(data, '&')
 		if idx == -1 {
 			buf.Write(data)
@@ -144,34 +150,34 @@ func DecodeEntities(str string) (string, error) {
 		buf.Write(data[:idx])
 		data = data[idx:]
 
-		// If there is only the '&' left here
-		if len(data) == 1 {
+		// Find the end of the entity within the bounded window.
+		window := data
+		if len(window) > maxEntityLen {
+			window = window[:maxEntityLen]
+		}
+		end := bytes.IndexByte(window, ';')
+
+		if end == -1 && len(window) == len(data) {
+			// No ';' in the rest of the input; no entity can terminate,
+			// so everything left is literal text.
 			buf.Write(data)
-			return buf.String(), nil
+			break
 		}
 
-		// Find the end of the entity
-		end := bytes.IndexByte(data, ';')
-		if end == -1 {
-			// it's not an entitiy. just a plain old '&' possibly with extra bytes
-			buf.Write(data)
-			return buf.String(), nil
+		// A candidate containing whitespace (or no nearby ';' at all) is not
+		// an entity. Emit the '&' literally and keep scanning: entities later
+		// in the string must still decode.
+		if end == -1 || bytes.ContainsAny(data[1:end], " \t\r\n") {
+			buf.WriteByte('&')
+			data = data[1:]
+			continue
 		}
 
-		// Check if there is a space somewhere within the 'entitiy'.
-		// If there is then skip the whole thing since it's not a real entity.
-		if strings.Contains(string(data[1:end]), " ") {
-			buf.Write(data)
-			return buf.String(), nil
-		} else {
-			buf.WriteString(html.UnescapeString(string(data[0 : end+1])))
-		}
-
-		// Skip the entity
+		buf.WriteString(html.UnescapeString(string(data[:end+1])))
 		data = data[end+1:]
 	}
 
-	return buf.String(), nil
+	return buf.String()
 }
 
 // ParseNameAddress parses name/email strings commonly

--- a/internal/shared/parseutils_test.go
+++ b/internal/shared/parseutils_test.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,12 +29,24 @@ func TestDecodeEntities(t *testing.T) {
 		{"&foo", "&foo"},
 		{"&lt", "&lt"},
 		{"&#", "&#"},
+
+		// A bare '&' must not stop later entities from decoding.
+		{"Fish & Chips &amp; more &lt;3", "Fish & Chips & more <3"},
+		{"a & b &amp; c & d &lt;e", "a & b & c & d <e"},
+		{"&unclosed &amp; ok", "&unclosed & ok"},
+		{"& &amp; &", "& & &"},
+
+		// Tab and newline also disqualify an entity candidate.
+		{"a &x\ty; &amp; b", "a &x\ty; & b"},
+		{"a &x\ny; &amp; b", "a &x\ny; & b"},
+
+		// A ';' beyond the entity-length window does not form an entity.
+		{"&" + strings.Repeat("x", 100) + "; &amp;", "&" + strings.Repeat("x", 100) + "; &"},
 	}
 
 	for _, test := range tests {
-		res, err := DecodeEntities(test.str)
-		assert.Nil(t, err, "cannot decode %q", test.str)
-		assert.Equal(t, res, test.res,
+		res := DecodeEntities(test.str)
+		assert.Equal(t, test.res, res,
 			"%q was decoded to %q instead of %q",
 			test.str, res, test.res)
 	}

--- a/testdata/parser/rss/issue_305_bare_ampersand.json
+++ b/testdata/parser/rss/issue_305_bare_ampersand.json
@@ -1,0 +1,5 @@
+{
+  "title": "Fish & Chips & more <3",
+  "items": [],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/issue_305_bare_ampersand.xml
+++ b/testdata/parser/rss/issue_305_bare_ampersand.xml
@@ -1,0 +1,9 @@
+<!--
+Description: a bare ampersand must not stop later entities in the same
+text from decoding (issue #305)
+-->
+<rss version="2.0">
+  <channel>
+    <title>Fish & Chips &amp; more &lt;3</title>
+  </channel>
+</rss>


### PR DESCRIPTION
Fixes #305.

When the text between an `&` and the next `;` contained a space, `DecodeEntities` wrote the entire remainder undecoded and returned, instead of emitting the `&` and continuing to scan. One bare ampersand disabled entity decoding for the rest of the string: `Fish & Chips &amp; more &lt;3` came out as `Fish & Chips &amp; more &lt;3` instead of `Fish & Chips & more <3`. Since the parser deliberately runs in non-strict mode to tolerate unescaped ampersands, this hit ordinary feed text.

Changes:

- On a non-entity candidate (whitespace before the `;`, tab and newline now included), emit the `&` literally, advance one byte, and keep scanning. Later entities decode.
- The search for the terminating `;` is bounded to a 64-byte window past the `&`. The longest named HTML entity is 33 bytes with delimiters, and an unbounded search made the scan quadratic on ampersand-heavy text with a distant stray `;`.
- Dropped the `(string, error)` return. `html.UnescapeString` cannot fail and no other error source exists; the `ErrTruncatedEntity` / `ErrInvalidNumericReference` sentinels were never returned by anything, so both are removed. Callers in `ParseText`, `StripCDATA`, and the atom parser are updated.

All existing `TestDecodeEntities` cases pass unchanged; they only covered inputs where nothing decodable followed the bare `&`. New unit cases cover entities after a bare `&`, tab/newline candidates, and the window bound, plus an end-to-end `issue_305_bare_ampersand` testdata pair that fails on master and passes with this change.