### PR TITLE
Stop using itunes:subtitle as the feed link

### DIFF
--- a/testdata/translator/rss/feed_link_-_rss_channel_atom_link_alternate.json
+++ b/testdata/translator/rss/feed_link_-_rss_channel_atom_link_alternate.json
@@ -1,0 +1,25 @@
+{
+  "link": "http://example.org/",
+  "links": [
+    "http://example.org/"
+  ],
+  "extensions": {
+    "atom": {
+      "link": [
+        {
+          "name": "link",
+          "value": "",
+          "attrs": {
+            "href": "http://example.org/",
+            "rel": "alternate",
+            "type": "text/html"
+          },
+          "children": {}
+        }
+      ]
+    }
+  },
+  "items": [],
+  "feedType": "rss",
+  "feedVersion": "2.0"
+}

--- a/testdata/translator/rss/feed_link_-_rss_channel_atom_link_alternate.xml
+++ b/testdata/translator/rss/feed_link_-_rss_channel_atom_link_alternate.xml
@@ -1,0 +1,9 @@
+<!--
+Description: with no channel link, an embedded atom:link with
+rel="alternate" becomes the feed link (issue #306)
+-->
+<rss version="2.0">
+  <channel>
+    <atom:link href="http://example.org/" rel="alternate" type="text/html"/>
+  </channel>
+</rss>

--- a/testdata/translator/rss/feed_link_-_rss_channel_itunes_subtitle.json
+++ b/testdata/translator/rss/feed_link_-_rss_channel_itunes_subtitle.json
@@ -1,0 +1,20 @@
+{
+  "itunesExt": {
+    "subtitle": "A show about things"
+  },
+  "extensions": {
+    "itunes": {
+      "subtitle": [
+        {
+          "name": "subtitle",
+          "value": "A show about things",
+          "attrs": {},
+          "children": {}
+        }
+      ]
+    }
+  },
+  "items": [],
+  "feedType": "rss",
+  "feedVersion": "2.0"
+}

--- a/testdata/translator/rss/feed_link_-_rss_channel_itunes_subtitle.xml
+++ b/testdata/translator/rss/feed_link_-_rss_channel_itunes_subtitle.xml
@@ -1,0 +1,9 @@
+<!--
+Description: itunes subtitle is prose, not a URL; it must not become the
+feed link (issue #306)
+-->
+<rss version="2.0">
+  <channel>
+    <itunes:subtitle>A show about things</itunes:subtitle>
+  </channel>
+</rss>

--- a/translator.go
+++ b/translator.go
@@ -107,11 +107,20 @@ func (t *DefaultRSSTranslator) translateFeedDescription(rss *rss.Feed) (desc str
 
 func (t *DefaultRSSTranslator) translateFeedLink(rss *rss.Feed) (link string) {
 	if rss.Link != "" {
-		link = rss.Link
-	} else if rss.ITunesExt != nil && rss.ITunesExt.Subtitle != "" {
-		link = rss.ITunesExt.Subtitle
+		return rss.Link
 	}
-	return
+	// Fall back to an embedded atom:link with rel="alternate" (or no rel),
+	// which points at the site the way <link> does.
+	for _, ex := range t.extensionsForKeys([]string{"atom", "atom10", "atom03"}, rss.Extensions) {
+		if links, ok := ex["link"]; ok {
+			for _, l := range links {
+				if l.Attrs["rel"] == "" || l.Attrs["rel"] == "alternate" {
+					return l.Attrs["href"]
+				}
+			}
+		}
+	}
+	return ""
 }
 
 func (t *DefaultRSSTranslator) translateFeedFeedLink(rss *rss.Feed) (link string) {


### PR DESCRIPTION
Fixes #306.

`translateFeedLink` fell back to `itunes:subtitle` when the channel had no `<link>`, so `Feed.Link` ended up holding prose like "A show about things". The analogous description fallback to `itunes:summary` one function up makes sense; this one looked like a copy of it that shouldn't have been.

Instead of just deleting the fallback, the link now falls back to an embedded `atom:link` with `rel="alternate"` (or no rel), which carries the same site URL `<link>` does. `rel="self"` links keep going to `FeedLink` only, matching the existing `feed_link_-_rss_channel_atom_link` fixture.

Tests: two new translator fixtures. `feed_link_-_rss_channel_itunes_subtitle` pins that a subtitle-only channel produces no `Feed.Link`, and `feed_link_-_rss_channel_atom_link_alternate` pins the new fallback. Both fail on master and pass here; full suite green.