### PR TITLE
Resolve every URI attribute in HTML content, not just the first

### DIFF
--- a/internal/shared/xmlbase.go
+++ b/internal/shared/xmlbase.go
@@ -160,7 +160,6 @@ func ResolveHTML(base *url.URL, relHTML string) (string, error) {
 					if absVal != nil && err == nil {
 						n.Attr[i].Val = absVal.String()
 					}
-					break
 				}
 			}
 		}

--- a/internal/shared/xmlbase_test.go
+++ b/internal/shared/xmlbase_test.go
@@ -59,3 +59,55 @@ func TestResolveHTMLResolvesAcrossElements(t *testing.T) {
 		t.Errorf("resolved = %q, want %q", got, want)
 	}
 }
+
+func TestResolveHTMLLeavesAbsoluteURLs(t *testing.T) {
+	base, _ := url.Parse("http://example.com/dir/")
+
+	got, err := ResolveHTML(base, `<a href="https://other.org/page.html">x</a>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `<a href="https://other.org/page.html">x</a>`
+	if got != want {
+		t.Errorf("resolved = %q, want %q", got, want)
+	}
+}
+
+// A malformed URI in one attribute is kept as-is; it must not error out or
+// stop other attributes from resolving.
+func TestResolveHTMLKeepsMalformedURIs(t *testing.T) {
+	base, _ := url.Parse("http://example.com/dir/")
+
+	got, err := ResolveHTML(base, `<video poster="http://%zz" src="v.mp4"></video>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `<video poster="http://%zz" src="http://example.com/dir/v.mp4"></video>`
+	if got != want {
+		t.Errorf("resolved = %q, want %q", got, want)
+	}
+}
+
+func TestResolveHTMLNilBase(t *testing.T) {
+	got, err := ResolveHTML(nil, `<a href="page.html">x</a>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != `<a href="page.html">x</a>` {
+		t.Errorf("resolved = %q, want input unchanged", got)
+	}
+}
+
+// Plain text must survive the html.Render round trip: the document wrapper
+// the renderer adds has to be stripped back off.
+func TestResolveHTMLPlainTextRoundTrip(t *testing.T) {
+	base, _ := url.Parse("http://example.com/dir/")
+
+	got, err := ResolveHTML(base, "hello world")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "hello world" {
+		t.Errorf("resolved = %q, want %q", got, "hello world")
+	}
+}

--- a/internal/shared/xmlbase_test.go
+++ b/internal/shared/xmlbase_test.go
@@ -31,3 +31,31 @@ func TestXmlBaseResolveUrlResolves(t *testing.T) {
 		t.Errorf("resolved = %q, want %q", got.String(), "http://example.com/a/b/x")
 	}
 }
+
+// Every URI attribute on an element must be resolved, not just the first
+// one encountered.
+func TestResolveHTMLResolvesAllURIAttributes(t *testing.T) {
+	base, _ := url.Parse("http://example.com/dir/")
+
+	got, err := ResolveHTML(base, `<video poster="p.jpg" src="v.mp4"></video>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `<video poster="http://example.com/dir/p.jpg" src="http://example.com/dir/v.mp4"></video>`
+	if got != want {
+		t.Errorf("resolved = %q, want %q", got, want)
+	}
+}
+
+func TestResolveHTMLResolvesAcrossElements(t *testing.T) {
+	base, _ := url.Parse("http://example.com/dir/")
+
+	got, err := ResolveHTML(base, `<a href="page.html"><img src="i.png"/></a>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `<a href="http://example.com/dir/page.html"><img src="http://example.com/dir/i.png"/></a>`
+	if got != want {
+		t.Errorf("resolved = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #307.

`ResolveHTML`'s attribute loop had a `break` after the first attribute matching `htmlURIAttrs`, so an element with more than one URI attribute got only the first resolved against xml:base. `<video poster="p.jpg" src="v.mp4">` came out with `poster` absolute and `src` still relative. Removing the `break` resolves them all.

Tests: `ResolveHTML` had no direct unit tests (only indirect coverage through the atom xml:base fixtures), so this adds two: one pinning multiple URI attributes on a single element (fails on master), one pinning resolution across nested elements.