### PR TITLE
Fix date layout that wrote the hour as 14

### DIFF
--- a/internal/shared/dateparser.go
+++ b/internal/shared/dateparser.go
@@ -166,7 +166,7 @@ var dateFormatsWithNamedZone = []string{
 	"mon,2 Jan 2006 15:04:05 MST",
 	"Mon, 2 Jan 15:04:05 MST",
 	"Mon, 2 Jan 06 15:04:05 MST",
-	"Mon,02 January 2006 14:04:05 MST",
+	"Mon,02 January 2006 15:04:05 MST",
 	"Mon, 02 Jan 2006 3:04:05 PM MST",
 	"Mon,02 Jan 2006 15:04 MST",
 	"Mon, 02 Jan 2006 15:04 MST",

--- a/internal/shared/dateparser_test.go
+++ b/internal/shared/dateparser_test.go
@@ -1,6 +1,9 @@
 package shared
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 // Named timezone abbreviations must resolve to the right offset, not a silent
 // zero offset (issue #237). The result is checked in UTC.
@@ -9,16 +12,17 @@ func TestParseDateNamedZones(t *testing.T) {
 		in      string
 		wantUTC string
 	}{
-		{"Mon, 02 Jan 2006 15:04:05 EST", "2006-01-02 20:04:05"},   // -5
-		{"Mon, 02 Jan 2006 15:04:05 EDT", "2006-01-02 19:04:05"},   // -4
-		{"Mon, 02 Jan 2006 15:04:05 CST", "2006-01-02 21:04:05"},   // -6
-		{"Mon, 02 Jan 2006 15:04:05 PST", "2006-01-02 23:04:05"},   // -8
-		{"Mon, 02 Jan 2006 15:04:05 PDT", "2006-01-02 22:04:05"},   // -7
-		{"Mon, 02 Jan 2006 15:04:05 CEST", "2006-01-02 13:04:05"},  // +2
-		{"Mon, 02 Jan 2006 15:04:05 GMT", "2006-01-02 15:04:05"},   // 0
-		{"Mon, 02 Jan 2006 15:04:05 UTC", "2006-01-02 15:04:05"},   // 0
-		{"Mon, 02 Jan 2006 15:04:05 -0700", "2006-01-02 22:04:05"}, // numeric still works
-		{"2006-01-02T15:04:05Z", "2006-01-02 15:04:05"},            // RFC3339 still works
+		{"Mon, 02 Jan 2006 15:04:05 EST", "2006-01-02 20:04:05"},    // -5
+		{"Mon,02 January 2006 15:04:05 EST", "2006-01-02 20:04:05"}, // comma without space, full month (issue #308)
+		{"Mon, 02 Jan 2006 15:04:05 EDT", "2006-01-02 19:04:05"},    // -4
+		{"Mon, 02 Jan 2006 15:04:05 CST", "2006-01-02 21:04:05"},    // -6
+		{"Mon, 02 Jan 2006 15:04:05 PST", "2006-01-02 23:04:05"},    // -8
+		{"Mon, 02 Jan 2006 15:04:05 PDT", "2006-01-02 22:04:05"},    // -7
+		{"Mon, 02 Jan 2006 15:04:05 CEST", "2006-01-02 13:04:05"},   // +2
+		{"Mon, 02 Jan 2006 15:04:05 GMT", "2006-01-02 15:04:05"},    // 0
+		{"Mon, 02 Jan 2006 15:04:05 UTC", "2006-01-02 15:04:05"},    // 0
+		{"Mon, 02 Jan 2006 15:04:05 -0700", "2006-01-02 22:04:05"},  // numeric still works
+		{"2006-01-02T15:04:05Z", "2006-01-02 15:04:05"},             // RFC3339 still works
 	}
 	for _, c := range cases {
 		got, err := ParseDate(c.in)
@@ -56,6 +60,22 @@ func TestParseDateFormats(t *testing.T) {
 		}
 		if g := got.UTC().Format("2006-01-02 15:04:05"); g != c.wantUTC {
 			t.Errorf("%q -> %s UTC, want %s", c.in, g, c.wantUTC)
+		}
+	}
+}
+
+// Every layout must be able to parse its own rendering of the reference time.
+// A malformed layout (like an hour written as 14) consumes fields twice and
+// can never match anything (issue #308).
+func TestDateLayoutsRoundTrip(t *testing.T) {
+	ref := time.Date(2006, time.January, 2, 15, 4, 5, 0, time.FixedZone("MST", -7*3600))
+	all := make([]string, 0, len(dateFormats)+len(dateFormatsWithNamedZone))
+	all = append(all, dateFormats...)
+	all = append(all, dateFormatsWithNamedZone...)
+	for _, layout := range all {
+		rendered := ref.Format(layout)
+		if _, err := time.Parse(layout, rendered); err != nil {
+			t.Errorf("layout %q cannot parse its own rendering %q: %v", layout, rendered, err)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #308.

In a Go layout `14` is not an hour token: the `1` parses as a numeric month and the `4` as a literal, so `"Mon,02 January 2006 14:04:05 MST"` consumed the month twice and failed on every input, including its own reference rendering. Dates like `Mon,02 January 2006 15:04:05 EST` (comma without space, full month name) failed entirely since no other layout covers that shape. The fix is `14` -> `15`.

Two tests:
- The repro case is added to the named-zone table test.
- A new round-trip guard renders the reference time through every layout in both tables and parses it back. It fails on master for exactly this layout and passes for all others, so this was the only broken entry, and future layout typos of this class get caught at test time.