### PR TITLE
Trim namespace URIs once, inside PrefixForNamespace

### DIFF
--- a/internal/shared/extparser.go
+++ b/internal/shared/extparser.go
@@ -11,8 +11,7 @@ import (
 // XML element is an extension element (if it has a
 // non empty prefix)
 func IsExtension(p *xpp.XMLPullParser) bool {
-	space := strings.TrimSpace(p.Space)
-	prefix := PrefixForNamespace(space, p)
+	prefix := PrefixForNamespace(p.Space, p)
 	return !(prefix == "" || prefix == "rss" || prefix == "rdf" || prefix == "content")
 }
 
@@ -91,6 +90,11 @@ func parseExtensionElement(p *xpp.XMLPullParser) (e ext.Extension, err error) {
 }
 
 func PrefixForNamespace(space string, p *xpp.XMLPullParser) string {
+	// Namespace attribute values may legally carry surrounding whitespace,
+	// and goxpp stores trimmed URIs as the p.Spaces keys. Trim here, once,
+	// so every lookup below (and every caller) agrees on the key.
+	space = strings.TrimSpace(space)
+
 	// First we check if the global namespace map
 	// contains an entry for this namespace/prefix.
 	// This way we can use the canonical prefix for this

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -357,7 +357,7 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 				}
 				item.Description = result
 			} else if name == "encoded" &&
-				shared.PrefixForNamespace(strings.TrimSpace(p.Space), p) == "content" {
+				shared.PrefixForNamespace(p.Space, p) == "content" {
 				result, err := shared.ParseText(p)
 				if err != nil {
 					return nil, err

--- a/testdata/parser/rss/issue_309_namespace_whitespace.json
+++ b/testdata/parser/rss/issue_309_namespace_whitespace.json
@@ -1,0 +1,29 @@
+{
+  "itunesExt": {
+    "author": "Example Author"
+  },
+  "extensions": {
+    "custom": {
+      "tag": [
+        {
+          "name": "tag",
+          "value": "value",
+          "attrs": {},
+          "children": {}
+        }
+      ]
+    },
+    "itunes": {
+      "author": [
+        {
+          "name": "author",
+          "value": "Example Author",
+          "attrs": {},
+          "children": {}
+        }
+      ]
+    }
+  },
+  "items": [],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/issue_309_namespace_whitespace.xml
+++ b/testdata/parser/rss/issue_309_namespace_whitespace.xml
@@ -1,0 +1,11 @@
+<!--
+Description: namespace declarations with surrounding whitespace in their
+URIs must still map to the canonical prefix (itunes) or the declared
+prefix (custom), not be filed under the raw URI (issue #309)
+-->
+<rss version="2.0" xmlns:itunes=" http://www.itunes.com/DTDs/PodCast-1.0.dtd" xmlns:custom=" http://example.org/ns ">
+  <channel>
+    <itunes:author>Example Author</itunes:author>
+    <custom:tag>value</custom:tag>
+  </channel>
+</rss>


### PR DESCRIPTION
Fixes #309.

`IsExtension` trimmed `p.Space` before the canonical-prefix lookup, but `ParseExtension` passed it raw, while goxpp stores trimmed URIs as the `p.Spaces` keys. A feed declaring `xmlns:itunes=" http://www.itunes.com/DTDs/PodCast-1.0.dtd"` (legal XML, attribute whitespace is preserved) was therefore recognized as an extension but filed under the raw untrimmed URI: `Extensions[" http://..."]["author"]` instead of `Extensions["itunes"]["author"]`, and `Feed.ITunesExt` came back nil.

The fix moves the trim inside `PrefixForNamespace` so the canonical-map lookup, the `p.Spaces` lookup, the fallback return value, and every caller all agree on the key. The now redundant pre-trims in `IsExtension` and the rss `encoded` branch are removed.

Test: new `issue_309_namespace_whitespace` testdata pair with whitespace-padded declarations covering both lookup paths, the canonical itunes namespace and a feed-defined custom one. Fails on master, passes here; full suite green.