### PR TITLE
Coerce out-of-range float sizes to 0 instead of overflow garbage

### DIFF
--- a/json/coerce.go
+++ b/json/coerce.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"encoding/json"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -100,16 +101,27 @@ func coerceInt64(raw json.RawMessage) int64 {
 			return i
 		}
 		if fl, err := n.Float64(); err == nil {
-			return int64(fl)
+			return float64ToInt64(fl)
 		}
 	}
 	var s string
 	if err := json.Unmarshal(raw, &s); err == nil {
 		if fl, err := strconv.ParseFloat(strings.TrimSpace(s), 64); err == nil {
-			return int64(fl)
+			return float64ToInt64(fl)
 		}
 	}
 	return 0
+}
+
+// float64ToInt64 converts fl to int64, returning 0 for NaN and values outside
+// the int64 range, where int64(fl) is implementation-defined. 0 matches the
+// fallback for other unusable values. 1<<63 is the first float64 that
+// overflows; -(1<<63) is exactly MinInt64 and still converts.
+func float64ToInt64(fl float64) int64 {
+	if math.IsNaN(fl) || fl >= 1<<63 || fl < -(1<<63) {
+		return 0
+	}
+	return int64(fl)
 }
 
 func isEmptyJSON(raw json.RawMessage) bool {

--- a/json/coerce_test.go
+++ b/json/coerce_test.go
@@ -46,3 +46,39 @@ func TestFloatSizeCoerced(t *testing.T) {
 		t.Fatalf("duration = %d, want 3600", att.DurationInSeconds)
 	}
 }
+
+// Values outside the int64 range (and NaN) must coerce to 0, the same
+// fallback as other unusable values, not implementation-defined garbage.
+func TestOutOfRangeSizeCoercedToZero(t *testing.T) {
+	f := parseFeed(t, `{"version":"https://jsonfeed.org/version/1","title":"t","items":[{"id":"a","attachments":[{"url":"u","size_in_bytes":1e300,"duration_in_seconds":-1e300}]}]}`)
+	att := (*f.Items[0].Attachments)[0]
+	if att.SizeInBytes != 0 {
+		t.Fatalf("size = %d, want 0", att.SizeInBytes)
+	}
+	if att.DurationInSeconds != 0 {
+		t.Fatalf("duration = %d, want 0", att.DurationInSeconds)
+	}
+}
+
+func TestOutOfRangeStringSizeCoercedToZero(t *testing.T) {
+	f := parseFeed(t, `{"version":"https://jsonfeed.org/version/1","title":"t","items":[{"id":"a","attachments":[{"url":"u","size_in_bytes":"1e300","duration_in_seconds":"NaN"}]}]}`)
+	att := (*f.Items[0].Attachments)[0]
+	if att.SizeInBytes != 0 {
+		t.Fatalf("size = %d, want 0", att.SizeInBytes)
+	}
+	if att.DurationInSeconds != 0 {
+		t.Fatalf("duration = %d, want 0", att.DurationInSeconds)
+	}
+}
+
+// The int64 boundaries themselves stay exact through the integer path.
+func TestInt64BoundarySizes(t *testing.T) {
+	f := parseFeed(t, `{"version":"https://jsonfeed.org/version/1","title":"t","items":[{"id":"a","attachments":[{"url":"u","size_in_bytes":9223372036854775807,"duration_in_seconds":-9223372036854775808}]}]}`)
+	att := (*f.Items[0].Attachments)[0]
+	if att.SizeInBytes != 9223372036854775807 {
+		t.Fatalf("size = %d, want MaxInt64", att.SizeInBytes)
+	}
+	if att.DurationInSeconds != -9223372036854775808 {
+		t.Fatalf("duration = %d, want MinInt64", att.DurationInSeconds)
+	}
+}


### PR DESCRIPTION
Fixes #310.

`int64(fl)` is implementation-defined in Go when `fl` is NaN or outside the int64 range, so `"size_in_bytes": 1e300` produced `SizeInBytes = -9223372036854775808`. A negative size is worse output than the function's own fallback of 0 for unparseable values.

Both conversion sites (the float path and the numeric-string path) now go through a helper that returns 0 for NaN and out-of-range values. The range check uses `fl >= 1<<63` (the first float64 that overflows) and `fl < -(1<<63)` (exactly MinInt64, which still converts), so the boundaries behave precisely: MaxInt64 and MinInt64 as JSON integers still come through exact via the `json.Number` integer path, which is pinned by a new test.

Tests: out-of-range positive/negative floats, out-of-range numeric strings, `"NaN"` as a string, and the int64 boundary values. The overflow cases fail on master and pass here.