### PR TITLE
Stream XML feeds through Parse; surface reader I/O errors

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -28,10 +28,13 @@ const (
 
 // DetectFeedType attempts to determine the type of feed
 // by looking for specific xml elements unique to the
-// various feed types.
+// various feed types. It returns FeedTypeUnknown when the
+// reader fails before the type can be determined.
 func DetectFeedType(feed io.Reader) FeedType {
 	buffer := new(bytes.Buffer)
-	buffer.ReadFrom(feed)
+	if _, err := buffer.ReadFrom(feed); err != nil {
+		return FeedTypeUnknown
+	}
 
 	var firstChar byte
 loop:

--- a/detector_test.go
+++ b/detector_test.go
@@ -2,10 +2,13 @@ package gofeed_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/mmcdole/gofeed"
 	"github.com/stretchr/testify/assert"
@@ -57,4 +60,11 @@ func ExampleDetectFeedType() {
 	if feedType == gofeed.FeedTypeRSS {
 		fmt.Println("Wow! This is an RSS feed!")
 	}
+}
+
+// A reader that fails mid-stream must yield FeedTypeUnknown, not a type
+// guessed from the partial prefix (issue #311).
+func TestDetectFeedType_ReaderError(t *testing.T) {
+	r := io.MultiReader(strings.NewReader(`<rss version="2.0"></rss>`), iotest.ErrReader(errors.New("boom")))
+	assert.Equal(t, gofeed.FeedTypeUnknown, gofeed.DetectFeedType(r))
 }

--- a/json/parser.go
+++ b/json/parser.go
@@ -14,7 +14,9 @@ func (ap *Parser) Parse(feed io.Reader) (*Feed, error) {
 	jsonFeed := &Feed{}
 
 	buffer := new(bytes.Buffer)
-	buffer.ReadFrom(feed)
+	if _, err := buffer.ReadFrom(feed); err != nil {
+		return nil, err
+	}
 
 	if err := json.Unmarshal(buffer.Bytes(), jsonFeed); err != nil {
 		return nil, err

--- a/json/parser_test.go
+++ b/json/parser_test.go
@@ -3,11 +3,14 @@ package json_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	jsonParser "github.com/mmcdole/gofeed/json"
 	"github.com/stretchr/testify/assert"
@@ -120,3 +123,15 @@ func TestParser_ParseInvalidAndStruct(t *testing.T) {
 }
 
 // TODO: Examples
+
+// An I/O error from the reader must surface as itself, not as a misleading
+// JSON syntax error from a truncated buffer (issue #311).
+func TestParser_Parse_ReaderError(t *testing.T) {
+	boom := errors.New("boom")
+	r := io.MultiReader(strings.NewReader(`{"version":"https://jsonfeed.org/version/1"`), iotest.ErrReader(boom))
+
+	_, err := (&jsonParser.Parser{}).Parse(r)
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want boom", err)
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -95,26 +95,21 @@ func NewParser() *Parser {
 // the universal gofeed.Feed.  It takes an
 // io.Reader which should return the xml/json content.
 func (f *Parser) Parse(feed io.Reader) (*Feed, error) {
-	// Wrap the feed io.Reader in a io.TeeReader
-	// so we can capture all the bytes read by the
-	// DetectFeedType function and construct a new
-	// reader with those bytes intact for when we
-	// attempt to parse the feeds.
-	var buf bytes.Buffer
-	tee := io.TeeReader(feed, &buf)
-	feedType := DetectFeedType(tee)
+	// Read the input once up front: detection inspects the bytes and the
+	// format parser reads them again, and reading here surfaces an I/O
+	// error as itself rather than as a failed type detection.
+	data, err := io.ReadAll(feed)
+	if err != nil {
+		return nil, err
+	}
 
-	// Glue the read bytes from the detect function
-	// back into a new reader
-	r := io.MultiReader(&buf, feed)
-
-	switch feedType {
+	switch DetectFeedType(bytes.NewReader(data)) {
 	case FeedTypeAtom:
-		return f.parseAtomFeed(r)
+		return f.parseAtomFeed(bytes.NewReader(data))
 	case FeedTypeRSS:
-		return f.parseRSSFeed(r)
+		return f.parseRSSFeed(bytes.NewReader(data))
 	case FeedTypeJSON:
-		return f.parseJSONFeed(r)
+		return f.parseJSONFeed(bytes.NewReader(data))
 	}
 
 	return nil, ErrFeedTypeNotDetected

--- a/parser.go
+++ b/parser.go
@@ -1,6 +1,7 @@
 package gofeed
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -91,25 +92,38 @@ func NewParser() *Parser {
 	return &fp
 }
 
+// detectionPeekSize is how many leading bytes Parse inspects to detect the
+// feed type. The root element appears within the first few KB of any real
+// feed; bounding the peek lets the XML parsers stream the rest of the input
+// instead of the whole feed being buffered just for detection. A feed whose
+// root element starts beyond this window is not detected.
+const detectionPeekSize = 4096
+
 // Parse parses a RSS or Atom or JSON feed into
 // the universal gofeed.Feed.  It takes an
 // io.Reader which should return the xml/json content.
+//
+// Only the first few KB are buffered to detect the feed type; RSS and Atom
+// content is then parsed incrementally from the reader. JSON feeds are read
+// fully into memory, as JSON decoding needs the complete document.
 func (f *Parser) Parse(feed io.Reader) (*Feed, error) {
-	// Read the input once up front: detection inspects the bytes and the
-	// format parser reads them again, and reading here surfaces an I/O
-	// error as itself rather than as a failed type detection.
-	data, err := io.ReadAll(feed)
-	if err != nil {
+	// Peek at the start of the stream to detect the feed type, without
+	// consuming it: the format parser below reads from the beginning. A
+	// reader error here surfaces as itself rather than as a failed type
+	// detection; io.EOF just means the whole feed fit inside the window.
+	br := bufio.NewReaderSize(feed, detectionPeekSize)
+	prefix, err := br.Peek(detectionPeekSize)
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 
-	switch DetectFeedType(bytes.NewReader(data)) {
+	switch DetectFeedType(bytes.NewReader(prefix)) {
 	case FeedTypeAtom:
-		return f.parseAtomFeed(bytes.NewReader(data))
+		return f.parseAtomFeed(br)
 	case FeedTypeRSS:
-		return f.parseRSSFeed(bytes.NewReader(data))
+		return f.parseRSSFeed(br)
 	case FeedTypeJSON:
-		return f.parseJSONFeed(bytes.NewReader(data))
+		return f.parseJSONFeed(br)
 	}
 
 	return nil, ErrFeedTypeNotDetected

--- a/parser_test.go
+++ b/parser_test.go
@@ -6,13 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	"github.com/mmcdole/gofeed"
@@ -397,4 +398,14 @@ func TestParserKeepOriginalFeed(t *testing.T) {
 	if orig.Title != "t" {
 		t.Errorf("original feed title = %q, want %q", orig.Title, "t")
 	}
+}
+
+// An I/O error from the reader must surface as itself, not be masked as a
+// failed type detection (issue #311).
+func TestParser_Parse_ReaderError(t *testing.T) {
+	boom := errors.New("boom")
+	r := io.MultiReader(strings.NewReader(`<rss version="2.0"><channel>`), iotest.ErrReader(boom))
+
+	_, err := gofeed.NewParser().Parse(r)
+	assert.ErrorIs(t, err, boom)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -409,3 +409,27 @@ func TestParser_Parse_ReaderError(t *testing.T) {
 	_, err := gofeed.NewParser().Parse(r)
 	assert.ErrorIs(t, err, boom)
 }
+
+// A feed much larger than the detection window must parse completely: the
+// format parser reads from the start of the stream, not from after the peek.
+func TestParser_Parse_LargeFeed(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString(`<rss version="2.0"><channel><title>big</title>`)
+	for i := 0; i < 2000; i++ {
+		fmt.Fprintf(&sb, `<item><title>item %d</title><guid>g%d</guid></item>`, i, i)
+	}
+	sb.WriteString(`</channel></rss>`)
+
+	feed, err := gofeed.NewParser().Parse(strings.NewReader(sb.String()))
+	assert.NoError(t, err)
+	assert.Len(t, feed.Items, 2000)
+	assert.Equal(t, "item 1999", feed.Items[1999].Title)
+}
+
+// Detection only inspects the first few KB; a root element pushed beyond
+// that window by leading junk is reported as undetected, not misparsed.
+func TestParser_Parse_RootBeyondDetectionWindow(t *testing.T) {
+	pad := "<!-- " + strings.Repeat("x", 8192) + " -->"
+	_, err := gofeed.NewParser().Parse(strings.NewReader(pad + `<rss version="2.0"><channel></channel></rss>`))
+	assert.ErrorIs(t, err, gofeed.ErrFeedTypeNotDetected)
+}


### PR DESCRIPTION
Fixes #311. Fixes #313.

`Parser.Parse` never actually streamed: `DetectFeedType` reads its input to EOF before answering, so by the time parsing started the whole feed sat in memory twice (the detector's buffer plus the TeeReader capture). Read errors were discarded along the way, in `DetectFeedType` and in `json.Parser.Parse`, so a reader failing mid-stream surfaced as `ErrFeedTypeNotDetected` or as `unexpected end of JSON input` instead of the real error.

Changes:

- `Parse` peeks at a bounded 4KB prefix (`bufio.Reader.Peek`), detects the type from that, and hands the stream itself to the format parser. RSS and Atom now parse incrementally from the reader, so the raw feed is never buffered whole. A read error during the peek returns as itself.
- `json.Parser.Parse` propagates its read error. JSON feeds still buffer the body, since `encoding/json` needs the complete document.
- `DetectFeedType` returns `FeedTypeUnknown` on a read error rather than guessing from the partial prefix. Its signature has no error return; retiring that is already on the v2 list (#315).
- Trade-off, documented on `Parse`: a feed whose root element starts beyond the 4KB window (pathological leading comments or doctype) is reported as undetected. Direct use of `rss.Parser`/`atom.Parser` is unaffected.

Tests: reader-error tests for all three sites (`iotest.ErrReader` behind a plausible prefix; the detector one previously "detected" RSS from the partial prefix), a large-feed test proving the peek handoff parses the full stream from the start, and a test pinning the detection-window behavior. `MaxByteSize` is unchanged and its existing test still passes: `ErrResponseTooLarge` surfaces through the peek or mid-parse. Also includes the pre-existing import-order gofmt fix in `parser_test.go`.