### PR TITLE
Bump goxpp to v1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.12.0
-	github.com/mmcdole/goxpp v1.2.2
+	github.com/mmcdole/goxpp v1.3.0
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli v1.22.17
 	golang.org/x/net v0.56.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/mmcdole/goxpp v1.2.2 h1:ebBx16f5wz7RBVHN+7SQC44baamX7hRmMC5iTv49t1A=
-github.com/mmcdole/goxpp v1.2.2/go.mod h1:wABIOPqKLu6wqQim/370Vaj/fsY1s+m/ytRiY1MYF7M=
+github.com/mmcdole/goxpp v1.3.0 h1:RD8CqRD88f1roH3I9jdIH5y0Vf7Uy/nHdJvBRY26pus=
+github.com/mmcdole/goxpp v1.3.0/go.mod h1:wABIOPqKLu6wqQim/370Vaj/fsY1s+m/ytRiY1MYF7M=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=


### PR DESCRIPTION
Picks up three goxpp fixes: parser poisoning after a DecodeElement unmarshal error instead of a state desync ending in a panic (mmcdole/goxpp#28), Space populated on EndTag events (mmcdole/goxpp#29), and Attribute preferring un-namespaced attributes over foreign-namespaced ones sharing a local name (mmcdole/goxpp#31).

Full suite passes against the new version; it also passed earlier against each fix via a local module replace before the goxpp PRs merged.