### PR TITLE
Migrate to goxpp v2

### DIFF
--- a/atom/parser.go
+++ b/atom/parser.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	ext "github.com/mmcdole/gofeed/extensions"
 	"github.com/mmcdole/gofeed/internal/shared"
-	xpp "github.com/mmcdole/goxpp"
+	xpp "github.com/mmcdole/goxpp/v2"
 )
 
 var (
@@ -29,7 +29,7 @@ type Parser struct{}
 // Parse parses an xml feed into an atom.Feed
 func (ap *Parser) Parse(feed io.Reader) (*Feed, error) {
 	feed = shared.NewControlCharFilterReader(feed)
-	p := xpp.NewXMLPullParser(feed, false, shared.NewReaderLabel)
+	p := shared.NewXMLParser(feed)
 
 	_, err := shared.FindRoot(p)
 	if err != nil {
@@ -39,7 +39,7 @@ func (ap *Parser) Parse(feed io.Reader) (*Feed, error) {
 	return ap.parseRoot(p)
 }
 
-func (ap *Parser) parseRoot(p *xpp.XMLPullParser) (*Feed, error) {
+func (ap *Parser) parseRoot(p *xpp.Parser) (*Feed, error) {
 	if err := p.Expect(xpp.StartTag, "feed"); err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func (ap *Parser) parseRoot(p *xpp.XMLPullParser) (*Feed, error) {
 
 		if tok == xpp.StartTag {
 
-			name := strings.ToLower(p.Name)
+			name := strings.ToLower(p.Name())
 
 			if shared.IsExtension(p) {
 				e, err := shared.ParseExtension(extensions, p)
@@ -197,7 +197,7 @@ func (ap *Parser) parseRoot(p *xpp.XMLPullParser) (*Feed, error) {
 	return atom, nil
 }
 
-func (ap *Parser) parseEntry(p *xpp.XMLPullParser) (*Entry, error) {
+func (ap *Parser) parseEntry(p *xpp.Parser) (*Entry, error) {
 	if err := p.Expect(xpp.StartTag, "entry"); err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func (ap *Parser) parseEntry(p *xpp.XMLPullParser) (*Entry, error) {
 
 		if tok == xpp.StartTag {
 
-			name := strings.ToLower(p.Name)
+			name := strings.ToLower(p.Name())
 
 			if shared.IsExtension(p) {
 				e, err := shared.ParseExtension(extensions, p)
@@ -350,7 +350,7 @@ func (ap *Parser) parseEntry(p *xpp.XMLPullParser) (*Entry, error) {
 	return entry, nil
 }
 
-func (ap *Parser) parseSource(p *xpp.XMLPullParser) (*Source, error) {
+func (ap *Parser) parseSource(p *xpp.Parser) (*Source, error) {
 
 	if err := p.Expect(xpp.StartTag, "source"); err != nil {
 		return nil, err
@@ -376,7 +376,7 @@ func (ap *Parser) parseSource(p *xpp.XMLPullParser) (*Source, error) {
 
 		if tok == xpp.StartTag {
 
-			name := strings.ToLower(p.Name)
+			name := strings.ToLower(p.Name())
 
 			if shared.IsExtension(p) {
 				e, err := shared.ParseExtension(extensions, p)
@@ -500,7 +500,7 @@ func (ap *Parser) parseSource(p *xpp.XMLPullParser) (*Source, error) {
 	return source, nil
 }
 
-func (ap *Parser) parseContent(p *xpp.XMLPullParser) (*Content, error) {
+func (ap *Parser) parseContent(p *xpp.Parser) (*Content, error) {
 	c := &Content{}
 	c.Type = p.Attribute("type")
 	c.Src = p.Attribute("src")
@@ -514,7 +514,7 @@ func (ap *Parser) parseContent(p *xpp.XMLPullParser) (*Content, error) {
 	return c, nil
 }
 
-func (ap *Parser) parsePerson(name string, p *xpp.XMLPullParser) (*Person, error) {
+func (ap *Parser) parsePerson(name string, p *xpp.Parser) (*Person, error) {
 
 	if err := p.Expect(xpp.StartTag, name); err != nil {
 		return nil, err
@@ -534,7 +534,7 @@ func (ap *Parser) parsePerson(name string, p *xpp.XMLPullParser) (*Person, error
 
 		if tok == xpp.StartTag {
 
-			name := strings.ToLower(p.Name)
+			name := strings.ToLower(p.Name())
 
 			if name == "name" {
 				result, err := ap.parseAtomText(p)
@@ -572,7 +572,7 @@ func (ap *Parser) parsePerson(name string, p *xpp.XMLPullParser) (*Person, error
 	return person, nil
 }
 
-func (ap *Parser) parseLink(p *xpp.XMLPullParser) (*Link, error) {
+func (ap *Parser) parseLink(p *xpp.Parser) (*Link, error) {
 	if err := p.Expect(xpp.StartTag, "link"); err != nil {
 		return nil, err
 	}
@@ -598,7 +598,7 @@ func (ap *Parser) parseLink(p *xpp.XMLPullParser) (*Link, error) {
 	return l, nil
 }
 
-func (ap *Parser) parseCategory(p *xpp.XMLPullParser) (*Category, error) {
+func (ap *Parser) parseCategory(p *xpp.Parser) (*Category, error) {
 	if err := p.Expect(xpp.StartTag, "category"); err != nil {
 		return nil, err
 	}
@@ -618,7 +618,7 @@ func (ap *Parser) parseCategory(p *xpp.XMLPullParser) (*Category, error) {
 	return c, nil
 }
 
-func (ap *Parser) parseGenerator(p *xpp.XMLPullParser) (*Generator, error) {
+func (ap *Parser) parseGenerator(p *xpp.Parser) (*Generator, error) {
 
 	if err := p.Expect(xpp.StartTag, "generator"); err != nil {
 		return nil, err
@@ -651,7 +651,7 @@ func (ap *Parser) parseGenerator(p *xpp.XMLPullParser) (*Generator, error) {
 	return g, nil
 }
 
-func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
+func (ap *Parser) parseAtomText(p *xpp.Parser) (string, error) {
 
 	var text struct {
 		Type     string `xml:"type,attr"`
@@ -660,7 +660,7 @@ func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
 	}
 
 	// get current base URL before it is clobbered by DecodeElement
-	base := p.BaseStack.Top()
+	base := p.BaseURL()
 	err := p.DecodeElement(&text)
 	if err != nil {
 		return "", err
@@ -704,7 +704,7 @@ func (ap *Parser) parseAtomText(p *xpp.XMLPullParser) (string, error) {
 	}
 
 	// resolve relative URIs in URI-containing elements according to xml:base
-	name := strings.ToLower(p.Name)
+	name := strings.ToLower(p.Name())
 	if atomUriElements[name] {
 		resolved, err := shared.XmlBaseResolveUrl(base, result)
 		if resolved != nil && err == nil {
@@ -734,11 +734,11 @@ func isBinaryMediaType(t string) bool {
 	return false
 }
 
-func (ap *Parser) parseLanguage(p *xpp.XMLPullParser) string {
+func (ap *Parser) parseLanguage(p *xpp.Parser) string {
 	return p.Attribute("lang")
 }
 
-func (ap *Parser) parseVersion(p *xpp.XMLPullParser) string {
+func (ap *Parser) parseVersion(p *xpp.Parser) string {
 	ver := p.Attribute("version")
 	if ver != "" {
 		return ver

--- a/detector.go
+++ b/detector.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/mmcdole/gofeed/internal/shared"
-	xpp "github.com/mmcdole/goxpp"
 )
 
 // FeedType represents one of the possible feed
@@ -56,14 +55,14 @@ loop:
 
 	if firstChar == '<' {
 		// Check if it's an XML based feed
-		p := xpp.NewXMLPullParser(bytes.NewReader(buffer.Bytes()), false, shared.NewReaderLabel)
+		p := shared.NewXMLParser(bytes.NewReader(buffer.Bytes()))
 
 		_, err := shared.FindRoot(p)
 		if err != nil {
 			return FeedTypeUnknown
 		}
 
-		name := strings.ToLower(p.Name)
+		name := strings.ToLower(p.Name())
 		switch name {
 		case "rdf":
 			return FeedTypeRSS

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.12.0
-	github.com/mmcdole/goxpp v1.3.0
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli v1.22.17
 	golang.org/x/net v0.56.0
@@ -14,6 +13,7 @@ require (
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/mmcdole/goxpp/v2 v2.0.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/mmcdole/goxpp v1.3.0 h1:RD8CqRD88f1roH3I9jdIH5y0Vf7Uy/nHdJvBRY26pus=
-github.com/mmcdole/goxpp v1.3.0/go.mod h1:wABIOPqKLu6wqQim/370Vaj/fsY1s+m/ytRiY1MYF7M=
+github.com/mmcdole/goxpp/v2 v2.0.0 h1:HrSCflxerUEqZQNq3u7ldtmE/XkwnTx4Zpq2DW4i5rQ=
+github.com/mmcdole/goxpp/v2 v2.0.0/go.mod h1:CUduYMnO9JB6Z/uqDn9Ormk/r8E9BsLQxHPWDZ961Os=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=

--- a/internal/shared/charsetconv.go
+++ b/internal/shared/charsetconv.go
@@ -1,8 +1,10 @@
 package shared
 
 import (
+	"encoding/xml"
 	"io"
 
+	xpp "github.com/mmcdole/goxpp/v2"
 	"golang.org/x/net/html/charset"
 )
 
@@ -14,4 +16,15 @@ func NewReaderLabel(label string, input io.Reader) (io.Reader, error) {
 	}
 
 	return conv, nil
+}
+
+// NewXMLParser returns a pull parser configured the way every gofeed parser
+// needs it: non-strict, so real-world feeds with unescaped entities and other
+// common mistakes still tokenize, and with charset conversion for feeds that
+// declare a non-UTF-8 encoding.
+func NewXMLParser(r io.Reader) *xpp.Parser {
+	d := xml.NewDecoder(r)
+	d.Strict = false
+	d.CharsetReader = NewReaderLabel
+	return xpp.New(d)
 }

--- a/internal/shared/extparser.go
+++ b/internal/shared/extparser.go
@@ -4,22 +4,22 @@ import (
 	"strings"
 
 	"github.com/mmcdole/gofeed/extensions"
-	"github.com/mmcdole/goxpp"
+	xpp "github.com/mmcdole/goxpp/v2"
 )
 
 // IsExtension returns whether or not the current
 // XML element is an extension element (if it has a
 // non empty prefix)
-func IsExtension(p *xpp.XMLPullParser) bool {
-	prefix := PrefixForNamespace(p.Space, p)
+func IsExtension(p *xpp.Parser) bool {
+	prefix := PrefixForNamespace(p.Space(), p)
 	return !(prefix == "" || prefix == "rss" || prefix == "rdf" || prefix == "content")
 }
 
 // ParseExtension parses the current element of the
 // XMLPullParser as an extension element and updates
 // the extension map
-func ParseExtension(fe ext.Extensions, p *xpp.XMLPullParser) (ext.Extensions, error) {
-	prefix := PrefixForNamespace(p.Space, p)
+func ParseExtension(fe ext.Extensions, p *xpp.Parser) (ext.Extensions, error) {
+	prefix := PrefixForNamespace(p.Space(), p)
 
 	result, err := parseExtensionElement(p)
 	if err != nil {
@@ -31,24 +31,24 @@ func ParseExtension(fe ext.Extensions, p *xpp.XMLPullParser) (ext.Extensions, er
 		fe[prefix] = map[string][]ext.Extension{}
 	}
 	// Ensure the extension element slice exists
-	if _, ok := fe[prefix][p.Name]; !ok {
-		fe[prefix][p.Name] = []ext.Extension{}
+	if _, ok := fe[prefix][p.Name()]; !ok {
+		fe[prefix][p.Name()] = []ext.Extension{}
 	}
 
-	fe[prefix][p.Name] = append(fe[prefix][p.Name], result)
+	fe[prefix][p.Name()] = append(fe[prefix][p.Name()], result)
 	return fe, nil
 }
 
-func parseExtensionElement(p *xpp.XMLPullParser) (e ext.Extension, err error) {
+func parseExtensionElement(p *xpp.Parser) (e ext.Extension, err error) {
 	if err = p.Expect(xpp.StartTag, "*"); err != nil {
 		return e, err
 	}
 
-	e.Name = p.Name
+	e.Name = p.Name()
 	e.Children = map[string][]ext.Extension{}
 	e.Attrs = map[string]string{}
 
-	for _, attr := range p.Attrs {
+	for _, attr := range p.Attrs() {
 		// TODO: Alright that we are stripping
 		// namespace information from attributes ?
 		e.Attrs[attr.Name.Local] = attr.Value
@@ -76,7 +76,7 @@ func parseExtensionElement(p *xpp.XMLPullParser) (e ext.Extension, err error) {
 
 			e.Children[child.Name] = append(e.Children[child.Name], child)
 		} else if tok == xpp.Text {
-			e.Value += p.Text
+			e.Value += p.Text()
 		}
 	}
 
@@ -89,10 +89,10 @@ func parseExtensionElement(p *xpp.XMLPullParser) (e ext.Extension, err error) {
 	return e, nil
 }
 
-func PrefixForNamespace(space string, p *xpp.XMLPullParser) string {
-	// Namespace attribute values may legally carry surrounding whitespace,
-	// and goxpp stores trimmed URIs as the p.Spaces keys. Trim here, once,
-	// so every lookup below (and every caller) agrees on the key.
+func PrefixForNamespace(space string, p *xpp.Parser) string {
+	// Namespace attribute values may legally carry surrounding whitespace.
+	// Trim here, once, so every lookup below (and every caller) agrees on
+	// the key.
 	space = strings.TrimSpace(space)
 
 	// First we check if the global namespace map
@@ -103,9 +103,9 @@ func PrefixForNamespace(space string, p *xpp.XMLPullParser) string {
 		return prefix
 	}
 
-	// Next we check if the feed itself defined this
-	// this namespace and return it if we have a result.
-	if prefix, ok := p.Spaces[space]; ok {
+	// Next we check if the feed itself declared a prefix for this
+	// namespace and return it if we have a result.
+	if prefix, ok := p.PrefixForURI(space); ok {
 		return prefix
 	}
 

--- a/internal/shared/extparser_test.go
+++ b/internal/shared/extparser_test.go
@@ -1,0 +1,158 @@
+package shared
+
+import (
+	"strings"
+	"testing"
+
+	xpp "github.com/mmcdole/goxpp/v2"
+
+	ext "github.com/mmcdole/gofeed/extensions"
+)
+
+// parserOn returns a NewXMLParser positioned on the first StartTag with the
+// given local name.
+func parserOn(t *testing.T, doc, name string) *xpp.Parser {
+	t.Helper()
+	p := NewXMLParser(strings.NewReader(doc))
+	for {
+		tok, err := p.NextToken()
+		if err != nil {
+			t.Fatalf("positioning on <%s>: %v", name, err)
+		}
+		if tok == xpp.StartTag && p.Name() == name {
+			return p
+		}
+		if tok == xpp.EndDocument {
+			t.Fatalf("no <%s> element found", name)
+		}
+	}
+}
+
+func TestIsExtension(t *testing.T) {
+	doc := `<rss xmlns:itunes="http://www.itunes.com/DTDs/PodCast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+		<channel>
+			<title>t</title>
+			<itunes:author>a</itunes:author>
+			<content:encoded>c</content:encoded>
+		</channel>
+	</rss>`
+
+	cases := []struct {
+		element string
+		want    bool
+	}{
+		{"title", false},   // no prefix
+		{"author", true},   // itunes prefix
+		{"encoded", false}, // content prefix is exempt
+	}
+	for _, c := range cases {
+		p := parserOn(t, doc, c.element)
+		if got := IsExtension(p); got != c.want {
+			t.Errorf("IsExtension(<%s>) = %v, want %v", c.element, got, c.want)
+		}
+	}
+}
+
+func TestParseExtension(t *testing.T) {
+	doc := `<rss xmlns:itunes="http://www.itunes.com/DTDs/PodCast-1.0.dtd">
+		<channel>
+			<itunes:owner>
+				<itunes:name>Alice</itunes:name>
+				<itunes:email>a@example.org</itunes:email>
+			</itunes:owner>
+			<itunes:category text="Tech"/>
+			<itunes:category text="News"/>
+		</channel>
+	</rss>`
+
+	p := NewXMLParser(strings.NewReader(doc))
+	extensions := ext.Extensions{}
+	for {
+		tok, err := p.NextToken()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tok == xpp.EndDocument {
+			break
+		}
+		if tok == xpp.StartTag && IsExtension(p) {
+			extensions, err = ParseExtension(extensions, p)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	owner := extensions["itunes"]["owner"]
+	if len(owner) != 1 {
+		t.Fatalf("owner entries = %d, want 1", len(owner))
+	}
+	if got := owner[0].Children["name"][0].Value; got != "Alice" {
+		t.Errorf("owner name = %q, want Alice", got)
+	}
+	if got := owner[0].Children["email"][0].Value; got != "a@example.org" {
+		t.Errorf("owner email = %q, want a@example.org", got)
+	}
+
+	cats := extensions["itunes"]["category"]
+	if len(cats) != 2 {
+		t.Fatalf("category entries = %d, want 2 (same-name elements must append)", len(cats))
+	}
+	if cats[0].Attrs["text"] != "Tech" || cats[1].Attrs["text"] != "News" {
+		t.Errorf("category attrs = %v, %v", cats[0].Attrs, cats[1].Attrs)
+	}
+	if cats[0].Name != "category" {
+		t.Errorf("extension Name = %q, want category", cats[0].Name)
+	}
+}
+
+func TestPrefixForNamespace(t *testing.T) {
+	doc := `<rss xmlns:pod="http://www.itunes.com/DTDs/PodCast-1.0.dtd" xmlns:custom="http://example.org/ns">
+		<channel><pod:author>a</pod:author></channel>
+	</rss>`
+	p := parserOn(t, doc, "author")
+
+	// A canonical namespace URI maps to its canonical prefix, not the
+	// prefix the feed used.
+	if got := PrefixForNamespace("http://www.itunes.com/DTDs/PodCast-1.0.dtd", p); got != "itunes" {
+		t.Errorf("canonical = %q, want itunes", got)
+	}
+	// Whitespace-padded URIs map the same way.
+	if got := PrefixForNamespace(" http://www.itunes.com/DTDs/PodCast-1.0.dtd ", p); got != "itunes" {
+		t.Errorf("padded canonical = %q, want itunes", got)
+	}
+	// A feed-declared namespace maps to the feed's prefix.
+	if got := PrefixForNamespace("http://example.org/ns", p); got != "custom" {
+		t.Errorf("feed-declared = %q, want custom", got)
+	}
+	// An undeclared prefix comes through encoding/xml as the raw prefix in
+	// Space; it maps to itself.
+	if got := PrefixForNamespace("media", p); got != "media" {
+		t.Errorf("undeclared = %q, want media", got)
+	}
+}
+
+// NewXMLParser must be non-strict (real feeds carry bare ampersands) and must
+// convert declared non-UTF-8 encodings.
+func TestNewXMLParserLeniencyAndCharset(t *testing.T) {
+	p := parserOn(t, `<root>Fish & Chips</root>`, "root")
+	text, err := p.NextText()
+	if err != nil {
+		t.Fatalf("bare ampersand should tokenize in non-strict mode: %v", err)
+	}
+	if !strings.Contains(text, "&") {
+		t.Errorf("text = %q, want the ampersand preserved", text)
+	}
+
+	// 0xE9 is é in ISO-8859-1 and invalid UTF-8; parsing it proves the
+	// charset reader is wired up.
+	latin1 := `<?xml version="1.0" encoding="ISO-8859-1"?><root>caf` + "\xe9" + `</root>`
+	p2 := parserOn(t, latin1, "root")
+	text, err = p2.NextText()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != "café" {
+		t.Errorf("text = %q, want café", text)
+	}
+}

--- a/internal/shared/parseutils.go
+++ b/internal/shared/parseutils.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	xpp "github.com/mmcdole/goxpp"
+	xpp "github.com/mmcdole/goxpp/v2"
 )
 
 var (
@@ -23,7 +23,7 @@ const CDATA_END = "]]>"
 // FindRoot iterates through the tokens of an xml document until
 // it encounters its first StartTag event.  It returns an error
 // if it reaches EndDocument before finding a tag.
-func FindRoot(p *xpp.XMLPullParser) (event xpp.XMLEventType, err error) {
+func FindRoot(p *xpp.Parser) (event xpp.EventType, err error) {
 	for {
 		event, err = p.Next()
 		if err != nil {
@@ -44,7 +44,7 @@ func FindRoot(p *xpp.XMLPullParser) (event xpp.XMLEventType, err error) {
 // from the current element of the XMLPullParser.
 // This function can handle parsing naked XML text from
 // an element.
-func ParseText(p *xpp.XMLPullParser) (string, error) {
+func ParseText(p *xpp.Parser) (string, error) {
 	var text struct {
 		Type     string `xml:"type,attr"`
 		InnerXML string `xml:",innerxml"`
@@ -69,8 +69,8 @@ func ParseText(p *xpp.XMLPullParser) (string, error) {
 // value against the element's xml:base when one is in scope. The base is
 // captured before ParseText runs, because ParseText consumes the element's end
 // tag, which pops the base off the stack.
-func ParseTextURL(p *xpp.XMLPullParser) (string, error) {
-	base := p.BaseStack.Top()
+func ParseTextURL(p *xpp.Parser) (string, error) {
+	base := p.BaseURL()
 	s, err := ParseText(p)
 	if err != nil {
 		return "", err

--- a/internal/shared/xmlbase.go
+++ b/internal/shared/xmlbase.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	xpp "github.com/mmcdole/goxpp"
+	xpp "github.com/mmcdole/goxpp/v2"
 	"golang.org/x/net/html"
 )
 
@@ -47,7 +47,7 @@ var (
 // NextTag is similar to goxpp's NextTag method except it wont throw an error
 // if the next immediate token isnt a Start/EndTag.  Instead, it will continue
 // to consume tokens until it hits a Start/EndTag or EndDocument.
-func NextTag(p *xpp.XMLPullParser) (event xpp.XMLEventType, err error) {
+func NextTag(p *xpp.Parser) (event xpp.EventType, err error) {
 	for {
 		event, err = p.Next()
 		if err != nil {
@@ -80,13 +80,13 @@ func NextTag(p *xpp.XMLPullParser) (event xpp.XMLEventType, err error) {
 }
 
 // resolve relative URI attributes according to xml:base
-func resolveAttrs(p *xpp.XMLPullParser) error {
-	for i, attr := range p.Attrs {
+func resolveAttrs(p *xpp.Parser) error {
+	for i, attr := range p.Attrs() {
 		lowerName := strings.ToLower(attr.Name.Local)
 		if uriAttrs[lowerName] {
-			absURL, err := XmlBaseResolveUrl(p.BaseStack.Top(), attr.Value)
+			absURL, err := XmlBaseResolveUrl(p.BaseURL(), attr.Value)
 			if err == nil && absURL != nil {
-				p.Attrs[i].Value = absURL.String()
+				p.Attrs()[i].Value = absURL.String()
 			}
 			// Continue processing even if URL resolution fails (e.g., for non-HTTP URIs like at://)
 		}

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -7,7 +7,7 @@ import (
 
 	ext "github.com/mmcdole/gofeed/extensions"
 	"github.com/mmcdole/gofeed/internal/shared"
-	xpp "github.com/mmcdole/goxpp"
+	xpp "github.com/mmcdole/goxpp/v2"
 )
 
 // Parser is a RSS Parser
@@ -16,7 +16,7 @@ type Parser struct{}
 // Parse parses an xml feed into an rss.Feed
 func (rp *Parser) Parse(feed io.Reader) (*Feed, error) {
 	feed = shared.NewControlCharFilterReader(feed)
-	p := xpp.NewXMLPullParser(feed, false, shared.NewReaderLabel)
+	p := shared.NewXMLParser(feed)
 
 	_, err := shared.FindRoot(p)
 	if err != nil {
@@ -26,7 +26,7 @@ func (rp *Parser) Parse(feed io.Reader) (*Feed, error) {
 	return rp.parseRoot(p)
 }
 
-func (rp *Parser) parseRoot(p *xpp.XMLPullParser) (*Feed, error) {
+func (rp *Parser) parseRoot(p *xpp.Parser) (*Feed, error) {
 	rssErr := p.Expect(xpp.StartTag, "rss")
 	rdfErr := p.Expect(xpp.StartTag, "rdf")
 	if rssErr != nil && rdfErr != nil {
@@ -59,7 +59,7 @@ func (rp *Parser) parseRoot(p *xpp.XMLPullParser) (*Feed, error) {
 				continue
 			}
 
-			name := strings.ToLower(p.Name)
+			name := strings.ToLower(p.Name())
 
 			if name == "channel" {
 				channel, err = rp.parseChannel(p)
@@ -115,7 +115,7 @@ func (rp *Parser) parseRoot(p *xpp.XMLPullParser) (*Feed, error) {
 	return channel, nil
 }
 
-func (rp *Parser) parseChannel(p *xpp.XMLPullParser) (rss *Feed, err error) {
+func (rp *Parser) parseChannel(p *xpp.Parser) (rss *Feed, err error) {
 	if err = p.Expect(xpp.StartTag, "channel"); err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func (rp *Parser) parseChannel(p *xpp.XMLPullParser) (rss *Feed, err error) {
 
 		if tok == xpp.StartTag {
 
-			name := strings.ToLower(p.Name)
+			name := strings.ToLower(p.Name())
 
 			if shared.IsExtension(p) {
 				ext, err := shared.ParseExtension(extensions, p)
@@ -313,7 +313,7 @@ func (rp *Parser) parseChannel(p *xpp.XMLPullParser) (rss *Feed, err error) {
 	return rss, nil
 }
 
-func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
+func (rp *Parser) parseItem(p *xpp.Parser) (item *Item, err error) {
 	if err = p.Expect(xpp.StartTag, "item"); err != nil {
 		return nil, err
 	}
@@ -336,7 +336,7 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 
 		if tok == xpp.StartTag {
 
-			name := strings.ToLower(p.Name)
+			name := strings.ToLower(p.Name())
 
 			if shared.IsExtension(p) {
 				ext, err := shared.ParseExtension(extensions, p)
@@ -357,7 +357,7 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 				}
 				item.Description = result
 			} else if name == "encoded" &&
-				shared.PrefixForNamespace(p.Space, p) == "content" {
+				shared.PrefixForNamespace(p.Space(), p) == "content" {
 				result, err := shared.ParseText(p)
 				if err != nil {
 					return nil, err
@@ -426,7 +426,7 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 				if item.Custom == nil {
 					item.Custom = make(map[string]string, 0)
 				}
-				item.Custom[p.Name] = result
+				item.Custom[p.Name()] = result
 			}
 		}
 	}
@@ -462,8 +462,8 @@ func (rp *Parser) parseItem(p *xpp.XMLPullParser) (item *Item, err error) {
 	return item, nil
 }
 
-func (rp *Parser) parseLink(p *xpp.XMLPullParser) (url string, err error) {
-	base := p.BaseStack.Top()
+func (rp *Parser) parseLink(p *xpp.Parser) (url string, err error) {
+	base := p.BaseURL()
 	href := p.Attribute("href")
 	url, err = shared.ParseText(p)
 	if err != nil {
@@ -476,7 +476,7 @@ func (rp *Parser) parseLink(p *xpp.XMLPullParser) (url string, err error) {
 	return url, err
 }
 
-func (rp *Parser) parseSource(p *xpp.XMLPullParser) (source *Source, err error) {
+func (rp *Parser) parseSource(p *xpp.Parser) (source *Source, err error) {
 	if err = p.Expect(xpp.StartTag, "source"); err != nil {
 		return nil, err
 	}
@@ -496,7 +496,7 @@ func (rp *Parser) parseSource(p *xpp.XMLPullParser) (source *Source, err error) 
 	return source, nil
 }
 
-func (rp *Parser) parseEnclosure(p *xpp.XMLPullParser) (enclosure *Enclosure, err error) {
+func (rp *Parser) parseEnclosure(p *xpp.Parser) (enclosure *Enclosure, err error) {
 	if err = p.Expect(xpp.StartTag, "enclosure"); err != nil {
 		return nil, err
 	}
@@ -513,7 +513,7 @@ func (rp *Parser) parseEnclosure(p *xpp.XMLPullParser) (enclosure *Enclosure, er
 			return enclosure, err
 		}
 
-		if p.Event == xpp.EndTag && p.Name == "enclosure" {
+		if p.Event() == xpp.EndTag && p.Name() == "enclosure" {
 			break
 		}
 	}
@@ -521,7 +521,7 @@ func (rp *Parser) parseEnclosure(p *xpp.XMLPullParser) (enclosure *Enclosure, er
 	return enclosure, nil
 }
 
-func (rp *Parser) parseImage(p *xpp.XMLPullParser) (image *Image, err error) {
+func (rp *Parser) parseImage(p *xpp.Parser) (image *Image, err error) {
 	if err = p.Expect(xpp.StartTag, "image"); err != nil {
 		return nil, err
 	}
@@ -539,7 +539,7 @@ func (rp *Parser) parseImage(p *xpp.XMLPullParser) (image *Image, err error) {
 		}
 
 		if tok == xpp.StartTag {
-			name := strings.ToLower(p.Name)
+			name := strings.ToLower(p.Name())
 
 			if name == "url" {
 				result, err := shared.ParseTextURL(p)
@@ -590,7 +590,7 @@ func (rp *Parser) parseImage(p *xpp.XMLPullParser) (image *Image, err error) {
 	return image, nil
 }
 
-func (rp *Parser) parseGUID(p *xpp.XMLPullParser) (guid *GUID, err error) {
+func (rp *Parser) parseGUID(p *xpp.Parser) (guid *GUID, err error) {
 	if err = p.Expect(xpp.StartTag, "guid"); err != nil {
 		return nil, err
 	}
@@ -622,7 +622,7 @@ func (rp *Parser) parseGUID(p *xpp.XMLPullParser) (guid *GUID, err error) {
 	return guid, nil
 }
 
-func (rp *Parser) parseCategory(p *xpp.XMLPullParser) (cat *Category, err error) {
+func (rp *Parser) parseCategory(p *xpp.Parser) (cat *Category, err error) {
 	if err = p.Expect(xpp.StartTag, "category"); err != nil {
 		return nil, err
 	}
@@ -643,7 +643,7 @@ func (rp *Parser) parseCategory(p *xpp.XMLPullParser) (cat *Category, err error)
 	return cat, nil
 }
 
-func (rp *Parser) parseTextInput(p *xpp.XMLPullParser) (*TextInput, error) {
+func (rp *Parser) parseTextInput(p *xpp.Parser) (*TextInput, error) {
 	if err := p.Expect(xpp.StartTag, "textinput"); err != nil {
 		return nil, err
 	}
@@ -661,7 +661,7 @@ func (rp *Parser) parseTextInput(p *xpp.XMLPullParser) (*TextInput, error) {
 		}
 
 		if tok == xpp.StartTag {
-			name := strings.ToLower(p.Name)
+			name := strings.ToLower(p.Name())
 
 			if name == "title" {
 				result, err := shared.ParseText(p)
@@ -700,7 +700,7 @@ func (rp *Parser) parseTextInput(p *xpp.XMLPullParser) (*TextInput, error) {
 	return ti, nil
 }
 
-func (rp *Parser) parseSkipHours(p *xpp.XMLPullParser) ([]string, error) {
+func (rp *Parser) parseSkipHours(p *xpp.Parser) ([]string, error) {
 	if err := p.Expect(xpp.StartTag, "skiphours"); err != nil {
 		return nil, err
 	}
@@ -718,7 +718,7 @@ func (rp *Parser) parseSkipHours(p *xpp.XMLPullParser) ([]string, error) {
 		}
 
 		if tok == xpp.StartTag {
-			name := strings.ToLower(p.Name)
+			name := strings.ToLower(p.Name())
 			if name == "hour" {
 				result, err := shared.ParseText(p)
 				if err != nil {
@@ -738,7 +738,7 @@ func (rp *Parser) parseSkipHours(p *xpp.XMLPullParser) ([]string, error) {
 	return hours, nil
 }
 
-func (rp *Parser) parseSkipDays(p *xpp.XMLPullParser) ([]string, error) {
+func (rp *Parser) parseSkipDays(p *xpp.Parser) ([]string, error) {
 	if err := p.Expect(xpp.StartTag, "skipdays"); err != nil {
 		return nil, err
 	}
@@ -756,7 +756,7 @@ func (rp *Parser) parseSkipDays(p *xpp.XMLPullParser) ([]string, error) {
 		}
 
 		if tok == xpp.StartTag {
-			name := strings.ToLower(p.Name)
+			name := strings.ToLower(p.Name())
 			if name == "day" {
 				result, err := shared.ParseText(p)
 				if err != nil {
@@ -776,7 +776,7 @@ func (rp *Parser) parseSkipDays(p *xpp.XMLPullParser) ([]string, error) {
 	return days, nil
 }
 
-func (rp *Parser) parseCloud(p *xpp.XMLPullParser) (*Cloud, error) {
+func (rp *Parser) parseCloud(p *xpp.Parser) (*Cloud, error) {
 	if err := p.Expect(xpp.StartTag, "cloud"); err != nil {
 		return nil, err
 	}
@@ -802,8 +802,8 @@ func (rp *Parser) parseCloud(p *xpp.XMLPullParser) (*Cloud, error) {
 	return cloud, nil
 }
 
-func (rp *Parser) parseVersion(p *xpp.XMLPullParser) (ver string) {
-	name := strings.ToLower(p.Name)
+func (rp *Parser) parseVersion(p *xpp.Parser) (ver string) {
+	name := strings.ToLower(p.Name())
 	if name == "rss" {
 		ver = p.Attribute("version")
 	} else if name == "rdf" {


### PR DESCRIPTION
Swaps `github.com/mmcdole/goxpp` v1.3.0 for `github.com/mmcdole/goxpp/v2` v2.0.0 (mmcdole/goxpp#39).

Changes, following the migration plan in mmcdole/goxpp#34:

- Cursor state reads become method calls: `p.Name` to `p.Name()`, same for `Space`, `Text`, `Attrs`, `Event`.
- Parser construction is centralized in a new `shared.NewXMLParser`, which builds the non-strict, charset-converting `xml.Decoder` that all three call sites (rss, atom, detector) were configuring through the old constructor arguments.
- `PrefixForNamespace` uses `PrefixForURI` for the feed-declared lookup instead of reading the removed `Spaces` map. The canonical-namespace map and the raw-prefix fallback are unchanged.
- The xml:base captures in `ParseTextURL`, `parseLink` and `parseAtomText` read `BaseURL()` instead of `BaseStack.Top()`.
- The in-place attribute rewriting in `resolveAttrs` is unchanged; v2 documents `Attrs()` as the live per-token slice and pins that contract with its own test.

No behavior change intended, and the full suite passes unchanged: every rss/atom/json parser fixture, all translator fixtures, and the detector tests. v2's stricter semantics (io.EOF after EndDocument, typed position errors) required no code changes because every parse loop already terminates on the EndDocument or EndTag event.
