### PR TITLE
Route the parser element loops through one shared helper

### DIFF
--- a/atom/parser.go
+++ b/atom/parser.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"io"
 	"strings"
+	"time"
 
 	ext "github.com/mmcdole/gofeed/extensions"
 	"github.com/mmcdole/gofeed/internal/shared"
@@ -56,119 +57,64 @@ func (ap *Parser) parseRoot(p *xpp.Parser) (*Feed, error) {
 	links := []*Link{}
 	extensions := ext.Extensions{}
 
-	for {
-		tok, err := shared.NextTag(p)
-		if err != nil {
-			return nil, err
+	err := shared.ForEachChild(p, func(name string) error {
+		if shared.IsExtension(p) {
+			var err error
+			extensions, err = shared.ParseExtension(extensions, p)
+			return err
 		}
-
-		if tok == xpp.EndTag {
-			break
-		}
-
-		if tok == xpp.StartTag {
-
-			name := strings.ToLower(p.Name())
-
-			if shared.IsExtension(p) {
-				e, err := shared.ParseExtension(extensions, p)
-				if err != nil {
-					return nil, err
-				}
-				extensions = e
-			} else if name == "title" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				atom.Title = result
-			} else if name == "id" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				atom.ID = result
-			} else if name == "updated" ||
-				name == "modified" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				atom.Updated = result
-				date, err := shared.ParseDate(result)
-				if err == nil {
-					utcDate := date.UTC()
-					atom.UpdatedParsed = &utcDate
-				}
-			} else if name == "subtitle" ||
-				name == "tagline" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				atom.Subtitle = result
-			} else if name == "link" {
-				result, err := ap.parseLink(p)
-				if err != nil {
-					return nil, err
-				}
-				links = append(links, result)
-			} else if name == "generator" {
-				result, err := ap.parseGenerator(p)
-				if err != nil {
-					return nil, err
-				}
-				atom.Generator = result
-			} else if name == "icon" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				atom.Icon = result
-			} else if name == "logo" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				atom.Logo = result
-			} else if name == "rights" ||
-				name == "copyright" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				atom.Rights = result
-			} else if name == "contributor" {
-				result, err := ap.parsePerson("contributor", p)
-				if err != nil {
-					return nil, err
-				}
-				contributors = append(contributors, result)
-			} else if name == "author" {
-				result, err := ap.parsePerson("author", p)
-				if err != nil {
-					return nil, err
-				}
-				authors = append(authors, result)
-			} else if name == "category" {
-				result, err := ap.parseCategory(p)
-				if err != nil {
-					return nil, err
-				}
-				categories = append(categories, result)
-			} else if name == "entry" {
-				result, err := ap.parseEntry(p)
-				if err != nil {
-					return nil, err
-				}
-				atom.Entries = append(atom.Entries, result)
-			} else {
-				err := p.Skip()
-				if err != nil {
-					return nil, err
-				}
+		var err error
+		switch name {
+		case "title":
+			atom.Title, err = ap.parseAtomText(p)
+		case "id":
+			atom.ID, err = ap.parseAtomText(p)
+		case "updated", "modified":
+			if atom.Updated, err = ap.parseAtomText(p); err == nil {
+				atom.UpdatedParsed = parseDateUTC(atom.Updated)
 			}
+		case "subtitle", "tagline":
+			atom.Subtitle, err = ap.parseAtomText(p)
+		case "link":
+			var link *Link
+			if link, err = ap.parseLink(p); err == nil {
+				links = append(links, link)
+			}
+		case "generator":
+			atom.Generator, err = ap.parseGenerator(p)
+		case "icon":
+			atom.Icon, err = ap.parseAtomText(p)
+		case "logo":
+			atom.Logo, err = ap.parseAtomText(p)
+		case "rights", "copyright":
+			atom.Rights, err = ap.parseAtomText(p)
+		case "contributor":
+			var person *Person
+			if person, err = ap.parsePerson("contributor", p); err == nil {
+				contributors = append(contributors, person)
+			}
+		case "author":
+			var person *Person
+			if person, err = ap.parsePerson("author", p); err == nil {
+				authors = append(authors, person)
+			}
+		case "category":
+			var cat *Category
+			if cat, err = ap.parseCategory(p); err == nil {
+				categories = append(categories, cat)
+			}
+		case "entry":
+			var entry *Entry
+			if entry, err = ap.parseEntry(p); err == nil {
+				atom.Entries = append(atom.Entries, entry)
+			}
+		default:
+			err = p.Skip()
 		}
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	if len(categories) > 0 {
@@ -198,6 +144,16 @@ func (ap *Parser) parseRoot(p *xpp.Parser) (*Feed, error) {
 	return atom, nil
 }
 
+// parseDateUTC parses a date the historical way: the raw text is kept by the
+// caller even when unparseable, and the parsed form is normalized to UTC.
+func parseDateUTC(text string) *time.Time {
+	if date, err := shared.ParseDate(text); err == nil {
+		utc := date.UTC()
+		return &utc
+	}
+	return nil
+}
+
 func (ap *Parser) parseEntry(p *xpp.Parser) (*Entry, error) {
 	if err := p.Expect(xpp.StartTag, "entry"); err != nil {
 		return nil, err
@@ -210,118 +166,61 @@ func (ap *Parser) parseEntry(p *xpp.Parser) (*Entry, error) {
 	links := []*Link{}
 	extensions := ext.Extensions{}
 
-	for {
-		tok, err := shared.NextTag(p)
-		if err != nil {
-			return nil, err
+	err := shared.ForEachChild(p, func(name string) error {
+		if shared.IsExtension(p) {
+			var err error
+			extensions, err = shared.ParseExtension(extensions, p)
+			return err
 		}
-
-		if tok == xpp.EndTag {
-			break
-		}
-
-		if tok == xpp.StartTag {
-
-			name := strings.ToLower(p.Name())
-
-			if shared.IsExtension(p) {
-				e, err := shared.ParseExtension(extensions, p)
-				if err != nil {
-					return nil, err
-				}
-				extensions = e
-			} else if name == "title" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				entry.Title = result
-			} else if name == "id" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				entry.ID = result
-			} else if name == "rights" ||
-				name == "copyright" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				entry.Rights = result
-			} else if name == "summary" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				entry.Summary = result
-			} else if name == "source" {
-				result, err := ap.parseSource(p)
-				if err != nil {
-					return nil, err
-				}
-				entry.Source = result
-			} else if name == "updated" ||
-				name == "modified" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				entry.Updated = result
-				date, err := shared.ParseDate(result)
-				if err == nil {
-					utcDate := date.UTC()
-					entry.UpdatedParsed = &utcDate
-				}
-			} else if name == "contributor" {
-				result, err := ap.parsePerson("contributor", p)
-				if err != nil {
-					return nil, err
-				}
-				contributors = append(contributors, result)
-			} else if name == "author" {
-				result, err := ap.parsePerson("author", p)
-				if err != nil {
-					return nil, err
-				}
-				authors = append(authors, result)
-			} else if name == "category" {
-				result, err := ap.parseCategory(p)
-				if err != nil {
-					return nil, err
-				}
-				categories = append(categories, result)
-			} else if name == "link" {
-				result, err := ap.parseLink(p)
-				if err != nil {
-					return nil, err
-				}
-				links = append(links, result)
-			} else if name == "published" ||
-				name == "issued" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				entry.Published = result
-				date, err := shared.ParseDate(result)
-				if err == nil {
-					utcDate := date.UTC()
-					entry.PublishedParsed = &utcDate
-				}
-			} else if name == "content" {
-				result, err := ap.parseContent(p)
-				if err != nil {
-					return nil, err
-				}
-				entry.Content = result
-			} else {
-				err := p.Skip()
-				if err != nil {
-					return nil, err
-				}
+		var err error
+		switch name {
+		case "title":
+			entry.Title, err = ap.parseAtomText(p)
+		case "id":
+			entry.ID, err = ap.parseAtomText(p)
+		case "rights", "copyright":
+			entry.Rights, err = ap.parseAtomText(p)
+		case "summary":
+			entry.Summary, err = ap.parseAtomText(p)
+		case "source":
+			entry.Source, err = ap.parseSource(p)
+		case "updated", "modified":
+			if entry.Updated, err = ap.parseAtomText(p); err == nil {
+				entry.UpdatedParsed = parseDateUTC(entry.Updated)
 			}
+		case "contributor":
+			var person *Person
+			if person, err = ap.parsePerson("contributor", p); err == nil {
+				contributors = append(contributors, person)
+			}
+		case "author":
+			var person *Person
+			if person, err = ap.parsePerson("author", p); err == nil {
+				authors = append(authors, person)
+			}
+		case "category":
+			var cat *Category
+			if cat, err = ap.parseCategory(p); err == nil {
+				categories = append(categories, cat)
+			}
+		case "link":
+			var link *Link
+			if link, err = ap.parseLink(p); err == nil {
+				links = append(links, link)
+			}
+		case "published", "issued":
+			if entry.Published, err = ap.parseAtomText(p); err == nil {
+				entry.PublishedParsed = parseDateUTC(entry.Published)
+			}
+		case "content":
+			entry.Content, err = ap.parseContent(p)
+		default:
+			err = p.Skip()
 		}
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	if len(categories) > 0 {
@@ -352,7 +251,6 @@ func (ap *Parser) parseEntry(p *xpp.Parser) (*Entry, error) {
 }
 
 func (ap *Parser) parseSource(p *xpp.Parser) (*Source, error) {
-
 	if err := p.Expect(xpp.StartTag, "source"); err != nil {
 		return nil, err
 	}
@@ -365,113 +263,59 @@ func (ap *Parser) parseSource(p *xpp.Parser) (*Source, error) {
 	links := []*Link{}
 	extensions := ext.Extensions{}
 
-	for {
-		tok, err := shared.NextTag(p)
-		if err != nil {
-			return nil, err
+	err := shared.ForEachChild(p, func(name string) error {
+		if shared.IsExtension(p) {
+			var err error
+			extensions, err = shared.ParseExtension(extensions, p)
+			return err
 		}
-
-		if tok == xpp.EndTag {
-			break
-		}
-
-		if tok == xpp.StartTag {
-
-			name := strings.ToLower(p.Name())
-
-			if shared.IsExtension(p) {
-				e, err := shared.ParseExtension(extensions, p)
-				if err != nil {
-					return nil, err
-				}
-				extensions = e
-			} else if name == "title" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				source.Title = result
-			} else if name == "id" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				source.ID = result
-			} else if name == "updated" ||
-				name == "modified" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				source.Updated = result
-				date, err := shared.ParseDate(result)
-				if err == nil {
-					utcDate := date.UTC()
-					source.UpdatedParsed = &utcDate
-				}
-			} else if name == "subtitle" ||
-				name == "tagline" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				source.Subtitle = result
-			} else if name == "link" {
-				result, err := ap.parseLink(p)
-				if err != nil {
-					return nil, err
-				}
-				links = append(links, result)
-			} else if name == "generator" {
-				result, err := ap.parseGenerator(p)
-				if err != nil {
-					return nil, err
-				}
-				source.Generator = result
-			} else if name == "icon" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				source.Icon = result
-			} else if name == "logo" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				source.Logo = result
-			} else if name == "rights" ||
-				name == "copyright" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				source.Rights = result
-			} else if name == "contributor" {
-				result, err := ap.parsePerson("contributor", p)
-				if err != nil {
-					return nil, err
-				}
-				contributors = append(contributors, result)
-			} else if name == "author" {
-				result, err := ap.parsePerson("author", p)
-				if err != nil {
-					return nil, err
-				}
-				authors = append(authors, result)
-			} else if name == "category" {
-				result, err := ap.parseCategory(p)
-				if err != nil {
-					return nil, err
-				}
-				categories = append(categories, result)
-			} else {
-				err := p.Skip()
-				if err != nil {
-					return nil, err
-				}
+		var err error
+		switch name {
+		case "title":
+			source.Title, err = ap.parseAtomText(p)
+		case "id":
+			source.ID, err = ap.parseAtomText(p)
+		case "updated", "modified":
+			if source.Updated, err = ap.parseAtomText(p); err == nil {
+				source.UpdatedParsed = parseDateUTC(source.Updated)
 			}
+		case "subtitle", "tagline":
+			source.Subtitle, err = ap.parseAtomText(p)
+		case "link":
+			var link *Link
+			if link, err = ap.parseLink(p); err == nil {
+				links = append(links, link)
+			}
+		case "generator":
+			source.Generator, err = ap.parseGenerator(p)
+		case "icon":
+			source.Icon, err = ap.parseAtomText(p)
+		case "logo":
+			source.Logo, err = ap.parseAtomText(p)
+		case "rights", "copyright":
+			source.Rights, err = ap.parseAtomText(p)
+		case "contributor":
+			var person *Person
+			if person, err = ap.parsePerson("contributor", p); err == nil {
+				contributors = append(contributors, person)
+			}
+		case "author":
+			var person *Person
+			if person, err = ap.parsePerson("author", p); err == nil {
+				authors = append(authors, person)
+			}
+		case "category":
+			var cat *Category
+			if cat, err = ap.parseCategory(p); err == nil {
+				categories = append(categories, cat)
+			}
+		default:
+			err = p.Skip()
 		}
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	if len(categories) > 0 {
@@ -516,54 +360,28 @@ func (ap *Parser) parseContent(p *xpp.Parser) (*Content, error) {
 }
 
 func (ap *Parser) parsePerson(name string, p *xpp.Parser) (*Person, error) {
-
 	if err := p.Expect(xpp.StartTag, name); err != nil {
 		return nil, err
 	}
 
 	person := &Person{}
 
-	for {
-		tok, err := shared.NextTag(p)
-		if err != nil {
-			return nil, err
+	err := shared.ForEachChild(p, func(child string) error {
+		var err error
+		switch child {
+		case "name":
+			person.Name, err = ap.parseAtomText(p)
+		case "email":
+			person.Email, err = ap.parseAtomText(p)
+		case "uri", "url", "homepage":
+			person.URI, err = ap.parseAtomText(p)
+		default:
+			err = p.Skip()
 		}
-
-		if tok == xpp.EndTag {
-			break
-		}
-
-		if tok == xpp.StartTag {
-
-			name := strings.ToLower(p.Name())
-
-			if name == "name" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				person.Name = result
-			} else if name == "email" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				person.Email = result
-			} else if name == "uri" ||
-				name == "url" ||
-				name == "homepage" {
-				result, err := ap.parseAtomText(p)
-				if err != nil {
-					return nil, err
-				}
-				person.URI = result
-			} else {
-				err := p.Skip()
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	if err := p.Expect(xpp.EndTag, name); err != nil {

--- a/internal/shared/loop.go
+++ b/internal/shared/loop.go
@@ -1,0 +1,29 @@
+package shared
+
+import (
+	"strings"
+
+	xpp "github.com/mmcdole/goxpp/v2"
+)
+
+// ForEachChild advances through the children of the element the parser is
+// currently on, calling handle for each child start tag with its lowercased
+// local name. handle must fully consume the child element, by parsing or
+// skipping it. ForEachChild returns once it reaches the enclosing element's
+// end tag, leaving the parser on it, so callers can assert it with Expect.
+func ForEachChild(p *xpp.Parser, handle func(name string) error) error {
+	for {
+		tok, err := NextTag(p)
+		if err != nil {
+			return err
+		}
+		if tok == xpp.EndTag {
+			return nil
+		}
+		if tok == xpp.StartTag {
+			if err := handle(strings.ToLower(p.Name())); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	ext "github.com/mmcdole/gofeed/extensions"
 	"github.com/mmcdole/gofeed/internal/shared"
@@ -41,51 +42,31 @@ func (rp *Parser) parseRoot(p *xpp.Parser) (*Feed, error) {
 
 	ver := rp.parseVersion(p)
 
-	for {
-		tok, err := shared.NextTag(p)
-		if err != nil {
-			return nil, err
+	err := shared.ForEachChild(p, func(name string) error {
+		// Skip any extensions found in the feed root.
+		if shared.IsExtension(p) {
+			return p.Skip()
 		}
-
-		if tok == xpp.EndTag {
-			break
-		}
-
-		if tok == xpp.StartTag {
-
-			// Skip any extensions found in the feed root.
-			if shared.IsExtension(p) {
-				p.Skip()
-				continue
-			}
-
-			name := strings.ToLower(p.Name())
-
-			if name == "channel" {
-				channel, err = rp.parseChannel(p)
-				if err != nil {
-					return nil, err
-				}
-			} else if name == "item" {
-				item, err := rp.parseItem(p)
-				if err != nil {
-					return nil, err
-				}
+		var err error
+		switch name {
+		case "channel":
+			channel, err = rp.parseChannel(p)
+		case "item":
+			var item *Item
+			if item, err = rp.parseItem(p); err == nil {
 				items = append(items, item)
-			} else if name == "textinput" {
-				textinput, err = rp.parseTextInput(p)
-				if err != nil {
-					return nil, err
-				}
-			} else if name == "image" {
-				image, err = rp.parseImage(p)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				p.Skip()
 			}
+		case "textinput":
+			textinput, err = rp.parseTextInput(p)
+		case "image":
+			image, err = rp.parseImage(p)
+		default:
+			err = p.Skip()
 		}
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	rssErr = p.Expect(xpp.EndTag, "rss")
@@ -127,163 +108,85 @@ func (rp *Parser) parseChannel(p *xpp.Parser) (rss *Feed, err error) {
 	categories := []*Category{}
 	links := []string{}
 
-	for {
-		tok, err := shared.NextTag(p)
-		if err != nil {
-			return nil, err
+	// parseDate mirrors the historical behavior for pubDate and
+	// lastBuildDate: the raw text is kept even when unparseable, and the
+	// parsed form is normalized to UTC.
+	parseDate := func(text string) *time.Time {
+		if date, err := shared.ParseDate(text); err == nil {
+			utc := date.UTC()
+			return &utc
 		}
+		return nil
+	}
 
-		if tok == xpp.EndTag {
-			break
+	err = shared.ForEachChild(p, func(name string) error {
+		if shared.IsExtension(p) {
+			extensions, err = shared.ParseExtension(extensions, p)
+			return err
 		}
-
-		if tok == xpp.StartTag {
-
-			name := strings.ToLower(p.Name())
-
-			if shared.IsExtension(p) {
-				ext, err := shared.ParseExtension(extensions, p)
-				if err != nil {
-					return nil, err
-				}
-				extensions = ext
-			} else if name == "title" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.Title = result
-			} else if name == "description" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.Description = result
-			} else if name == "link" {
-				result, err := rp.parseLink(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.Link = result
-				links = append(links, result)
-			} else if name == "language" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.Language = result
-			} else if name == "copyright" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.Copyright = result
-			} else if name == "managingeditor" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.ManagingEditor = result
-			} else if name == "webmaster" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.WebMaster = result
-			} else if name == "pubdate" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.PubDate = result
-				date, err := shared.ParseDate(result)
-				if err == nil {
-					utcDate := date.UTC()
-					rss.PubDateParsed = &utcDate
-				}
-			} else if name == "lastbuilddate" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.LastBuildDate = result
-				date, err := shared.ParseDate(result)
-				if err == nil {
-					utcDate := date.UTC()
-					rss.LastBuildDateParsed = &utcDate
-				}
-			} else if name == "generator" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.Generator = result
-			} else if name == "docs" {
-				result, err := shared.ParseTextURL(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.Docs = result
-			} else if name == "ttl" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.TTL = result
-			} else if name == "rating" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.Rating = result
-			} else if name == "skiphours" {
-				result, err := rp.parseSkipHours(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.SkipHours = result
-			} else if name == "skipdays" {
-				result, err := rp.parseSkipDays(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.SkipDays = result
-			} else if name == "item" {
-				result, err := rp.parseItem(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.Items = append(rss.Items, result)
-			} else if name == "cloud" {
-				result, err := rp.parseCloud(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.Cloud = result
-			} else if name == "category" {
-				result, err := rp.parseCategory(p)
-				if err != nil {
-					return nil, err
-				}
-				categories = append(categories, result)
-			} else if name == "image" {
-				result, err := rp.parseImage(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.Image = result
-			} else if name == "textinput" {
-				result, err := rp.parseTextInput(p)
-				if err != nil {
-					return nil, err
-				}
-				rss.TextInput = result
-			} else {
-				// Skip element as it isn't an extension and not
-				// part of the spec
-				p.Skip()
+		var err error
+		switch name {
+		case "title":
+			rss.Title, err = shared.ParseText(p)
+		case "description":
+			rss.Description, err = shared.ParseText(p)
+		case "link":
+			if rss.Link, err = rp.parseLink(p); err == nil {
+				links = append(links, rss.Link)
 			}
+		case "language":
+			rss.Language, err = shared.ParseText(p)
+		case "copyright":
+			rss.Copyright, err = shared.ParseText(p)
+		case "managingeditor":
+			rss.ManagingEditor, err = shared.ParseText(p)
+		case "webmaster":
+			rss.WebMaster, err = shared.ParseText(p)
+		case "pubdate":
+			if rss.PubDate, err = shared.ParseText(p); err == nil {
+				rss.PubDateParsed = parseDate(rss.PubDate)
+			}
+		case "lastbuilddate":
+			if rss.LastBuildDate, err = shared.ParseText(p); err == nil {
+				rss.LastBuildDateParsed = parseDate(rss.LastBuildDate)
+			}
+		case "generator":
+			rss.Generator, err = shared.ParseText(p)
+		case "docs":
+			rss.Docs, err = shared.ParseTextURL(p)
+		case "ttl":
+			rss.TTL, err = shared.ParseText(p)
+		case "rating":
+			rss.Rating, err = shared.ParseText(p)
+		case "skiphours":
+			rss.SkipHours, err = rp.parseSkipHours(p)
+		case "skipdays":
+			rss.SkipDays, err = rp.parseSkipDays(p)
+		case "item":
+			var item *Item
+			if item, err = rp.parseItem(p); err == nil {
+				rss.Items = append(rss.Items, item)
+			}
+		case "cloud":
+			rss.Cloud, err = rp.parseCloud(p)
+		case "category":
+			var cat *Category
+			if cat, err = rp.parseCategory(p); err == nil {
+				categories = append(categories, cat)
+			}
+		case "image":
+			rss.Image, err = rp.parseImage(p)
+		case "textinput":
+			rss.TextInput, err = rp.parseTextInput(p)
+		default:
+			// Skip element as it isn't an extension and not part of
+			// the spec.
+			err = p.Skip()
 		}
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	if err = p.Expect(xpp.EndTag, "channel"); err != nil {
@@ -324,111 +227,60 @@ func (rp *Parser) parseItem(p *xpp.Parser) (item *Item, err error) {
 	enclosures := []*Enclosure{}
 	links := []string{}
 
-	for {
-		tok, err := shared.NextTag(p)
-		if err != nil {
-			return nil, err
+	err = shared.ForEachChild(p, func(name string) error {
+		if shared.IsExtension(p) {
+			extensions, err = shared.ParseExtension(extensions, p)
+			return err
 		}
-
-		if tok == xpp.EndTag {
-			break
-		}
-
-		if tok == xpp.StartTag {
-
-			name := strings.ToLower(p.Name())
-
-			if shared.IsExtension(p) {
-				ext, err := shared.ParseExtension(extensions, p)
-				if err != nil {
-					return nil, err
-				}
-				item.Extensions = ext
-			} else if name == "title" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				item.Title = result
-			} else if name == "description" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				item.Description = result
-			} else if name == "encoded" &&
-				shared.PrefixForNamespace(p.Space(), p) == "content" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				item.Content = result
-			} else if name == "link" {
-				result, err := rp.parseLink(p)
-				if err != nil {
-					return nil, err
-				}
-				item.Link = result
-				links = append(links, result)
-			} else if name == "author" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				item.Author = result
-			} else if name == "comments" {
-				result, err := shared.ParseTextURL(p)
-				if err != nil {
-					return nil, err
-				}
-				item.Comments = result
-			} else if name == "pubdate" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				item.PubDate = result
-				date, err := shared.ParseDate(result)
-				if err == nil {
-					utcDate := date.UTC()
-					item.PubDateParsed = &utcDate
-				}
-			} else if name == "source" {
-				result, err := rp.parseSource(p)
-				if err != nil {
-					return nil, err
-				}
-				item.Source = result
-			} else if name == "enclosure" {
-				result, err := rp.parseEnclosure(p)
-				if err != nil {
-					return nil, err
-				}
-				item.Enclosure = result
-				enclosures = append(enclosures, result)
-			} else if name == "guid" {
-				result, err := rp.parseGUID(p)
-				if err != nil {
-					return nil, err
-				}
-				item.GUID = result
-			} else if name == "category" {
-				result, err := rp.parseCategory(p)
-				if err != nil {
-					return nil, err
-				}
-				categories = append(categories, result)
+		var err error
+		switch name {
+		case "title":
+			item.Title, err = shared.ParseText(p)
+		case "description":
+			item.Description, err = shared.ParseText(p)
+		case "encoded":
+			if shared.PrefixForNamespace(p.Space(), p) == "content" {
+				item.Content, err = shared.ParseText(p)
 			} else {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					continue
-				}
-				if item.Custom == nil {
-					item.Custom = make(map[string]string, 0)
-				}
-				item.Custom[p.Name()] = result
+				err = rp.parseItemCustom(p, item)
 			}
+		case "link":
+			if item.Link, err = rp.parseLink(p); err == nil {
+				links = append(links, item.Link)
+			}
+		case "author":
+			item.Author, err = shared.ParseText(p)
+		case "comments":
+			item.Comments, err = shared.ParseTextURL(p)
+		case "pubdate":
+			if item.PubDate, err = shared.ParseText(p); err == nil {
+				if date, derr := shared.ParseDate(item.PubDate); derr == nil {
+					utc := date.UTC()
+					item.PubDateParsed = &utc
+				}
+			}
+		case "source":
+			item.Source, err = rp.parseSource(p)
+		case "enclosure":
+			var enc *Enclosure
+			if enc, err = rp.parseEnclosure(p); err == nil {
+				item.Enclosure = enc
+				enclosures = append(enclosures, enc)
+			}
+		case "guid":
+			item.GUID, err = rp.parseGUID(p)
+		case "category":
+			var cat *Category
+			if cat, err = rp.parseCategory(p); err == nil {
+				categories = append(categories, cat)
+			}
+		default:
+			err = rp.parseItemCustom(p, item)
 		}
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	if len(enclosures) > 0 {
@@ -460,6 +312,21 @@ func (rp *Parser) parseItem(p *xpp.Parser) (item *Item, err error) {
 	}
 
 	return item, nil
+}
+
+// parseItemCustom stores an unrecognized item child in the Custom map,
+// keyed by its original-case name. Duplicate names keep the last value.
+func (rp *Parser) parseItemCustom(p *xpp.Parser, item *Item) error {
+	key := p.Name()
+	result, err := shared.ParseText(p)
+	if err != nil {
+		return err
+	}
+	if item.Custom == nil {
+		item.Custom = make(map[string]string)
+	}
+	item.Custom[key] = result
+	return nil
 }
 
 func (rp *Parser) parseLink(p *xpp.Parser) (url string, err error) {
@@ -506,16 +373,14 @@ func (rp *Parser) parseEnclosure(p *xpp.Parser) (enclosure *Enclosure, err error
 	enclosure.Length = p.Attribute("length")
 	enclosure.Type = p.Attribute("type")
 
-	// Ignore any enclosure tag
-	for {
-		_, err := p.Next()
-		if err != nil {
-			return enclosure, err
-		}
+	// The spec defines <enclosure> as an empty element; skip to the
+	// matching end tag so stray children can't desync the parse.
+	if err = p.Skip(); err != nil {
+		return nil, err
+	}
 
-		if p.Event() == xpp.EndTag && p.Name() == "enclosure" {
-			break
-		}
+	if err = p.Expect(xpp.EndTag, "enclosure"); err != nil {
+		return nil, err
 	}
 
 	return enclosure, nil
@@ -528,59 +393,28 @@ func (rp *Parser) parseImage(p *xpp.Parser) (image *Image, err error) {
 
 	image = &Image{}
 
-	for {
-		tok, err := shared.NextTag(p)
-		if err != nil {
-			return image, err
+	err = shared.ForEachChild(p, func(name string) error {
+		var err error
+		switch name {
+		case "url":
+			image.URL, err = shared.ParseTextURL(p)
+		case "title":
+			image.Title, err = shared.ParseText(p)
+		case "link":
+			image.Link, err = shared.ParseTextURL(p)
+		case "width":
+			image.Width, err = shared.ParseText(p)
+		case "height":
+			image.Height, err = shared.ParseText(p)
+		case "description":
+			image.Description, err = shared.ParseText(p)
+		default:
+			err = p.Skip()
 		}
-
-		if tok == xpp.EndTag {
-			break
-		}
-
-		if tok == xpp.StartTag {
-			name := strings.ToLower(p.Name())
-
-			if name == "url" {
-				result, err := shared.ParseTextURL(p)
-				if err != nil {
-					return nil, err
-				}
-				image.URL = result
-			} else if name == "title" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				image.Title = result
-			} else if name == "link" {
-				result, err := shared.ParseTextURL(p)
-				if err != nil {
-					return nil, err
-				}
-				image.Link = result
-			} else if name == "width" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				image.Width = result
-			} else if name == "height" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				image.Height = result
-			} else if name == "description" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				image.Description = result
-			} else {
-				p.Skip()
-			}
-		}
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	if err = p.Expect(xpp.EndTag, "image"); err != nil {
@@ -650,47 +484,24 @@ func (rp *Parser) parseTextInput(p *xpp.Parser) (*TextInput, error) {
 
 	ti := &TextInput{}
 
-	for {
-		tok, err := shared.NextTag(p)
-		if err != nil {
-			return nil, err
+	err := shared.ForEachChild(p, func(name string) error {
+		var err error
+		switch name {
+		case "title":
+			ti.Title, err = shared.ParseText(p)
+		case "description":
+			ti.Description, err = shared.ParseText(p)
+		case "name":
+			ti.Name, err = shared.ParseText(p)
+		case "link":
+			ti.Link, err = shared.ParseText(p)
+		default:
+			err = p.Skip()
 		}
-
-		if tok == xpp.EndTag {
-			break
-		}
-
-		if tok == xpp.StartTag {
-			name := strings.ToLower(p.Name())
-
-			if name == "title" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				ti.Title = result
-			} else if name == "description" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				ti.Description = result
-			} else if name == "name" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				ti.Name = result
-			} else if name == "link" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				ti.Link = result
-			} else {
-				p.Skip()
-			}
-		}
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	if err := p.Expect(xpp.EndTag, "textinput"); err != nil {
@@ -707,28 +518,18 @@ func (rp *Parser) parseSkipHours(p *xpp.Parser) ([]string, error) {
 
 	hours := []string{}
 
-	for {
-		tok, err := shared.NextTag(p)
-		if err != nil {
-			return nil, err
+	err := shared.ForEachChild(p, func(name string) error {
+		if name != "hour" {
+			return p.Skip()
 		}
-
-		if tok == xpp.EndTag {
-			break
+		hour, err := shared.ParseText(p)
+		if err == nil {
+			hours = append(hours, hour)
 		}
-
-		if tok == xpp.StartTag {
-			name := strings.ToLower(p.Name())
-			if name == "hour" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				hours = append(hours, result)
-			} else {
-				p.Skip()
-			}
-		}
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	if err := p.Expect(xpp.EndTag, "skiphours"); err != nil {
@@ -745,28 +546,18 @@ func (rp *Parser) parseSkipDays(p *xpp.Parser) ([]string, error) {
 
 	days := []string{}
 
-	for {
-		tok, err := shared.NextTag(p)
-		if err != nil {
-			return nil, err
+	err := shared.ForEachChild(p, func(name string) error {
+		if name != "day" {
+			return p.Skip()
 		}
-
-		if tok == xpp.EndTag {
-			break
+		day, err := shared.ParseText(p)
+		if err == nil {
+			days = append(days, day)
 		}
-
-		if tok == xpp.StartTag {
-			name := strings.ToLower(p.Name())
-			if name == "day" {
-				result, err := shared.ParseText(p)
-				if err != nil {
-					return nil, err
-				}
-				days = append(days, result)
-			} else {
-				p.Skip()
-			}
-		}
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	if err := p.Expect(xpp.EndTag, "skipdays"); err != nil {

--- a/rss/parser_test.go
+++ b/rss/parser_test.go
@@ -55,3 +55,10 @@ func TestParser_Parse_CloudTruncated(t *testing.T) {
 }
 
 // TODO: Examples
+
+func TestParser_Parse_UnknownRoot(t *testing.T) {
+	// Neither <rss> nor <rdf>: the parse must fail rather than return an
+	// empty feed.
+	_, err := (&rss.Parser{}).Parse(strings.NewReader(`<foo><channel/></foo>`))
+	assert.Error(t, err)
+}

--- a/testdata/parser/atom/issue_275_atom03_version.json
+++ b/testdata/parser/atom/issue_275_atom03_version.json
@@ -1,0 +1,5 @@
+{
+  "title": "old",
+  "entries": [],
+  "version": "0.3"
+}

--- a/testdata/parser/atom/issue_275_atom03_version.xml
+++ b/testdata/parser/atom/issue_275_atom03_version.xml
@@ -1,0 +1,7 @@
+<!--
+Description: the atom 0.3 namespace sets FeedVersion 0.3 (issue #275
+coverage)
+-->
+<feed xmlns="http://purl.org/atom/ns#">
+  <title>old</title>
+</feed>

--- a/testdata/parser/atom/issue_275_extensions_and_source.json
+++ b/testdata/parser/atom/issue_275_extensions_and_source.json
@@ -1,0 +1,87 @@
+{
+  "title": "t",
+  "categories": [
+    {
+      "term": "cat1",
+      "label": "Cat"
+    }
+  ],
+  "entries": [
+    {
+      "title": "e1",
+      "source": {
+        "title": "src",
+        "updated": "2003-12-13T18:30:02Z",
+        "updatedParsed": "2003-12-13T18:30:02Z",
+        "categories": [
+          {
+            "term": "sc"
+          }
+        ],
+        "extensions": {
+          "dc": {
+            "rights": [
+              {
+                "name": "rights",
+                "value": "r",
+                "attrs": {},
+                "children": {}
+              }
+            ]
+          }
+        }
+      },
+      "extensions": {
+        "dc": {
+          "subject": [
+            {
+              "name": "subject",
+              "value": "s",
+              "attrs": {},
+              "children": {}
+            }
+          ]
+        }
+      }
+    },
+    {
+      "title": "e2",
+      "content": {
+        "type": "video/mp4",
+        "value": "hello"
+      }
+    },
+    {
+      "title": "e3",
+      "content": {
+        "type": "application/json",
+        "value": "{\"a\":1}"
+      }
+    },
+    {
+      "title": "e4",
+      "authors": [
+        {
+          "name": "An Author"
+        }
+      ],
+      "content": {
+        "type": "application/atom+xml",
+        "value": "\u0026lt;x/\u0026gt;"
+      }
+    }
+  ],
+  "extensions": {
+    "dc": {
+      "creator": [
+        {
+          "name": "creator",
+          "value": "Feed Creator",
+          "attrs": {},
+          "children": {}
+        }
+      ]
+    }
+  },
+  "version": "1.0"
+}

--- a/testdata/parser/atom/issue_275_extensions_and_source.xml
+++ b/testdata/parser/atom/issue_275_extensions_and_source.xml
@@ -1,0 +1,36 @@
+<!--
+Description: extensions at feed, entry and source level, categories at feed
+level, unknown elements everywhere, atom 0.3 modified inside source, and
+binary and unknown content types (issue #275 coverage)
+-->
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title>t</title>
+  <category term="cat1" label="Cat"/>
+  <dc:creator>Feed Creator</dc:creator>
+  <unknownfeed>x</unknownfeed>
+  <entry>
+    <title>e1</title>
+    <dc:subject>s</dc:subject>
+    <unknownentry>y</unknownentry>
+    <source>
+      <title>src</title>
+      <modified>2003-12-13T18:30:02Z</modified>
+      <dc:rights>r</dc:rights>
+      <unknownsource>z</unknownsource>
+      <category term="sc"/>
+    </source>
+  </entry>
+  <entry>
+    <title>e2</title>
+    <content type="video/mp4">aGVsbG8=</content>
+  </entry>
+  <entry>
+    <title>e3</title>
+    <content type="application/json">{"a":1}</content>
+  </entry>
+  <entry>
+    <title>e4</title>
+    <author><name>An Author</name><unknownperson>q</unknownperson></author>
+    <content type="application/atom+xml">&lt;x/&gt;</content>
+  </entry>
+</feed>

--- a/testdata/parser/rss/issue_275_channel_item_extensions.json
+++ b/testdata/parser/rss/issue_275_channel_item_extensions.json
@@ -1,0 +1,66 @@
+{
+  "dcExt": {
+    "creator": [
+      "Chan Creator"
+    ]
+  },
+  "extensions": {
+    "dc": {
+      "creator": [
+        {
+          "name": "creator",
+          "value": "Chan Creator",
+          "attrs": {},
+          "children": {}
+        }
+      ]
+    }
+  },
+  "items": [
+    {
+      "dcExt": {
+        "subject": [
+          "Subj"
+        ]
+      },
+      "itunesExt": {
+        "author": "Item Author"
+      },
+      "extensions": {
+        "custom": {
+          "thing": [
+            {
+              "name": "thing",
+              "value": "val",
+              "attrs": {
+                "attr": "v"
+              },
+              "children": {}
+            }
+          ]
+        },
+        "dc": {
+          "subject": [
+            {
+              "name": "subject",
+              "value": "Subj",
+              "attrs": {},
+              "children": {}
+            }
+          ]
+        },
+        "itunes": {
+          "author": [
+            {
+              "name": "author",
+              "value": "Item Author",
+              "attrs": {},
+              "children": {}
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/issue_275_channel_item_extensions.xml
+++ b/testdata/parser/rss/issue_275_channel_item_extensions.xml
@@ -1,0 +1,15 @@
+<!--
+Description: dublin core at channel level and itunes, dc and custom
+extensions at item level parse into Extensions plus the mapped
+ITunesExt/DublinCoreExt structs (issue #275 coverage)
+-->
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:itunes="http://www.itunes.com/DTDs/PodCast-1.0.dtd" xmlns:custom="http://example.org/ns">
+  <channel>
+    <dc:creator>Chan Creator</dc:creator>
+    <item>
+      <itunes:author>Item Author</itunes:author>
+      <dc:subject>Subj</dc:subject>
+      <custom:thing attr="v">val</custom:thing>
+    </item>
+  </channel>
+</rss>

--- a/testdata/parser/rss/issue_275_unknown_children.json
+++ b/testdata/parser/rss/issue_275_unknown_children.json
@@ -1,0 +1,17 @@
+{
+  "title": "t",
+  "image": {
+    "url": "http://example.org/i.png"
+  },
+  "skipHours": [
+    "1"
+  ],
+  "skipDays": [
+    "Monday"
+  ],
+  "textInput": {
+    "title": "ti"
+  },
+  "items": [],
+  "version": "1.0"
+}

--- a/testdata/parser/rss/issue_275_unknown_children.xml
+++ b/testdata/parser/rss/issue_275_unknown_children.xml
@@ -1,0 +1,16 @@
+<!--
+Description: extension and unknown elements at the feed root are skipped, as
+are unknown children of image, textinput, skipHours and skipDays
+(issue #275 coverage)
+-->
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:whatever>x</dc:whatever>
+  <unknownroot>y</unknownroot>
+  <channel>
+    <title>t</title>
+    <image><url>http://example.org/i.png</url><junk>z</junk></image>
+    <skipHours><hour>1</hour><junk/></skipHours>
+    <skipDays><day>Monday</day><junk/></skipDays>
+    <textinput><title>ti</title><junk/></textinput>
+  </channel>
+</rdf:RDF>


### PR DESCRIPTION
Fixes #275.

Every multi-child element in the rss and atom parsers hand-rolled the same skeleton: loop NextTag, break on EndTag, lowercase the name, dispatch through an if/else ladder, with a five-line parse-assign-check block per element. The new `shared.ForEachChild` owns that skeleton once, each leaf case is one assignment line, and skipping unknown elements is the structural default, so the class of branch that neither parses nor skips (the shape behind #303) can no longer be written by accident.

Covers all three items from the issue:

- **One terminating loop helper.** Eleven loops across the two parsers (root/channel/item/image/textinput/skipHours/skipDays in rss; root/entry/source/person in atom) now go through `ForEachChild`. `parseEnclosure`'s raw `p.Next()` loop is replaced with `p.Skip()`, matching the #304 cloud fix, so stray children of an enclosure can't desync the parse. `parseExtensionElement`'s loop stays: it needs Text tokens, which the tag-oriented helper deliberately hides, and under goxpp v2 its termination is already guaranteed (truncation is a decoder error, calls after end of document return io.EOF).
- **Skip errors checked.** The helper structure checks every `p.Skip()` return; none are discarded anymore. The rss custom-field fallback also propagates ParseText errors instead of continuing mid-element; under goxpp v2 the parser is poisoned at that point anyway, so the old `continue` only deferred the identical failure by one call.
- **Leaf duplication removed.** rss/parser.go goes 818 to 609 lines and atom/parser.go 826 to 626. The channel/item extension accumulation is now symmetric, removing the aliasing where the item side compiled only because ParseExtension mutates its map in place.

Same discipline as #332: a coverage audit ran first, and four new fixture pairs plus a unit test pin the previously unpinned branches this refactor touches (item-level extensions including the aliasing line, root-level and container-level unknown-element skipping, atom feed/entry/source extensions and categories, the atom 0.3 namespace version, binary and unknown content types). After the fixtures, the only uncovered parser branches are two physically unreachable ones. The full suite passes at every commit.
