### PR TITLE
Capture unknown elements into one extension tree

### DIFF
--- a/atom/parser.go
+++ b/atom/parser.go
@@ -109,7 +109,9 @@ func (ap *Parser) parseRoot(p *xpp.Parser) (*Feed, error) {
 				atom.Entries = append(atom.Entries, entry)
 			}
 		default:
-			err = p.Skip()
+			// Not part of the spec: capture it into the extension map
+			// under the _custom pseudo namespace instead of dropping it.
+			extensions, _, err = shared.ParseCustom(extensions, p)
 		}
 		return err
 	})
@@ -215,7 +217,9 @@ func (ap *Parser) parseEntry(p *xpp.Parser) (*Entry, error) {
 		case "content":
 			entry.Content, err = ap.parseContent(p)
 		default:
-			err = p.Skip()
+			// Not part of the spec: capture it into the extension map
+			// under the _custom pseudo namespace instead of dropping it.
+			extensions, _, err = shared.ParseCustom(extensions, p)
 		}
 		return err
 	})
@@ -310,7 +314,9 @@ func (ap *Parser) parseSource(p *xpp.Parser) (*Source, error) {
 				categories = append(categories, cat)
 			}
 		default:
-			err = p.Skip()
+			// Not part of the spec: capture it into the extension map
+			// under the _custom pseudo namespace instead of dropping it.
+			extensions, _, err = shared.ParseCustom(extensions, p)
 		}
 		return err
 	})

--- a/extension_helpers.go
+++ b/extension_helpers.go
@@ -1,0 +1,71 @@
+package gofeed
+
+import (
+	ext "github.com/mmcdole/gofeed/extensions"
+)
+
+// CustomNamespace is the pseudo namespace under which non-namespaced unknown
+// elements are filed in Extensions, preserving nesting, attributes and
+// repetition.
+const CustomNamespace = "_custom"
+
+// GetExtension returns the extension elements for the given namespace prefix
+// and element name, or nil when absent. Non-namespaced custom elements live
+// under CustomNamespace.
+func (f *Feed) GetExtension(namespace, element string) []ext.Extension {
+	return extensionsFor(f.Extensions, namespace, element)
+}
+
+// GetExtension returns the extension elements for the given namespace prefix
+// and element name, or nil when absent. Non-namespaced custom elements live
+// under CustomNamespace.
+func (i *Item) GetExtension(namespace, element string) []ext.Extension {
+	return extensionsFor(i.Extensions, namespace, element)
+}
+
+// GetExtensionValue returns the text of the first matching extension
+// element, or "" when absent.
+func (f *Feed) GetExtensionValue(namespace, element string) string {
+	return firstExtensionValue(f.Extensions, namespace, element)
+}
+
+// GetExtensionValue returns the text of the first matching extension
+// element, or "" when absent.
+func (i *Item) GetExtensionValue(namespace, element string) string {
+	return firstExtensionValue(i.Extensions, namespace, element)
+}
+
+// GetCustomValue returns the text of the first non-namespaced custom element
+// with the given name, or "" when absent. Unlike the flat Custom map, the
+// backing extension tree also holds nested elements, attributes and repeated
+// values; use GetExtension(CustomNamespace, element) for those.
+func (f *Feed) GetCustomValue(element string) string {
+	return firstExtensionValue(f.Extensions, CustomNamespace, element)
+}
+
+// GetCustomValue returns the text of the first non-namespaced custom element
+// with the given name, or "" when absent. Unlike the flat Custom map, the
+// backing extension tree also holds nested elements, attributes and repeated
+// values; use GetExtension(CustomNamespace, element) for those.
+func (i *Item) GetCustomValue(element string) string {
+	return firstExtensionValue(i.Extensions, CustomNamespace, element)
+}
+
+func extensionsFor(exts ext.Extensions, namespace, element string) []ext.Extension {
+	if exts == nil {
+		return nil
+	}
+	nsMap, ok := exts[namespace]
+	if !ok {
+		return nil
+	}
+	return nsMap[element]
+}
+
+func firstExtensionValue(exts ext.Extensions, namespace, element string) string {
+	matches := extensionsFor(exts, namespace, element)
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[0].Value
+}

--- a/extension_helpers_test.go
+++ b/extension_helpers_test.go
@@ -1,0 +1,56 @@
+package gofeed_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mmcdole/gofeed"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtensionHelpers(t *testing.T) {
+	feed := `<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+		<channel>
+			<customFeedId>feed-1</customFeedId>
+			<item>
+				<dc:creator>Jane</dc:creator>
+				<event><venue city="Austin">Hall</venue></event>
+				<simple>plain</simple>
+				<simple>again</simple>
+			</item>
+		</channel>
+	</rss>`
+
+	f, err := gofeed.NewParser().Parse(strings.NewReader(feed))
+	assert.NoError(t, err)
+	item := f.Items[0]
+
+	// Namespaced extensions through the same accessors.
+	assert.Equal(t, "Jane", item.GetExtensionValue("dc", "creator"))
+	assert.Len(t, item.GetExtension("dc", "creator"), 1)
+
+	// Feed level custom element, previously dropped entirely.
+	assert.Equal(t, "feed-1", f.GetCustomValue("customFeedId"))
+
+	// Item level custom values, including repetition the flat map loses.
+	assert.Equal(t, "plain", item.GetCustomValue("simple"))
+	assert.Len(t, item.GetExtension(gofeed.CustomNamespace, "simple"), 2)
+
+	// Nested custom elements keep children and attributes in the tree.
+	events := item.GetExtension(gofeed.CustomNamespace, "event")
+	if assert.Len(t, events, 1) {
+		venue := events[0].Children["venue"][0]
+		assert.Equal(t, "Hall", venue.Value)
+		assert.Equal(t, "Austin", venue.Attrs["city"])
+	}
+
+	// The flat Custom map still works for childless elements (last wins),
+	// and nested elements no longer corrupt it.
+	assert.Equal(t, "again", item.Custom["simple"])
+	_, hasEvent := item.Custom["event"]
+	assert.False(t, hasEvent)
+
+	// Absent lookups are empty, not panics.
+	assert.Nil(t, f.GetExtension("nope", "x"))
+	assert.Equal(t, "", item.GetCustomValue("absent"))
+}

--- a/feed.go
+++ b/feed.go
@@ -32,10 +32,13 @@ type Feed struct {
 	DublinCoreExt   *ext.DublinCoreExtension `json:"dcExt,omitempty"`
 	ITunesExt       *ext.ITunesFeedExtension `json:"itunesExt,omitempty"`
 	Extensions      ext.Extensions           `json:"extensions,omitempty"`
-	Custom          map[string]string        `json:"custom,omitempty"`
-	Items           []*Item                  `json:"items"`
-	FeedType        string                   `json:"feedType"`
-	FeedVersion     string                   `json:"feedVersion"`
+	// Custom is a flat view of non-namespaced unknown elements. Deprecated:
+	// use Extensions[CustomNamespace] (or GetCustomValue), which keeps
+	// nesting, attributes and repeated elements.
+	Custom      map[string]string `json:"custom,omitempty"`
+	Items       []*Item           `json:"items"`
+	FeedType    string            `json:"feedType"`
+	FeedVersion string            `json:"feedVersion"`
 
 	// originalFeed holds the source *rss.Feed, *atom.Feed, or *json.Feed when
 	// the parser was configured with KeepOriginalFeed. It is unexported (and so
@@ -81,7 +84,11 @@ type Item struct {
 	DublinCoreExt   *ext.DublinCoreExtension `json:"dcExt,omitempty"`
 	ITunesExt       *ext.ITunesItemExtension `json:"itunesExt,omitempty"`
 	Extensions      ext.Extensions           `json:"extensions,omitempty"`
-	Custom          map[string]string        `json:"custom,omitempty"`
+	// Custom is a flat view of childless non-namespaced unknown elements,
+	// last value wins. Deprecated: use Extensions[CustomNamespace] (or
+	// GetCustomValue), which keeps nesting, attributes and repeated
+	// elements.
+	Custom map[string]string `json:"custom,omitempty"`
 }
 
 // Person is an individual specified in a feed

--- a/internal/shared/extparser.go
+++ b/internal/shared/extparser.go
@@ -175,3 +175,25 @@ var canonicalNamespaces = map[string]string{
 	"http://www.w3.org/XML/1998/namespace":                           "xml",
 	"http://podlove.org/simple-chapters":                             "psc",
 }
+
+// CustomPrefix is the pseudo namespace prefix that files non-namespaced
+// unknown elements in the extension map.
+const CustomPrefix = "_custom"
+
+// ParseCustom parses the current element as an arbitrary non-namespaced
+// element and files it in the extension map under CustomPrefix, preserving
+// nesting, attributes and repetition the same way namespaced extensions are
+// kept. The parsed element is also returned so callers can maintain
+// compatibility shims from it.
+func ParseCustom(fe ext.Extensions, p *xpp.Parser) (ext.Extensions, ext.Extension, error) {
+	result, err := parseExtensionElement(p)
+	if err != nil {
+		return nil, ext.Extension{}, err
+	}
+
+	if _, ok := fe[CustomPrefix]; !ok {
+		fe[CustomPrefix] = map[string][]ext.Extension{}
+	}
+	fe[CustomPrefix][result.Name] = append(fe[CustomPrefix][result.Name], result)
+	return fe, result, nil
+}

--- a/internal/shared/extparser_test.go
+++ b/internal/shared/extparser_test.go
@@ -156,3 +156,67 @@ func TestNewXMLParserLeniencyAndCharset(t *testing.T) {
 		t.Errorf("text = %q, want café", text)
 	}
 }
+
+func TestParseCustom(t *testing.T) {
+	doc := `<rss version="2.0">
+		<channel>
+			<item>
+				<event><venue city="Austin">Hall</venue></event>
+				<simple>plain</simple>
+				<simple>again</simple>
+			</item>
+		</channel>
+	</rss>`
+
+	p := NewXMLParser(strings.NewReader(doc))
+	extensions := ext.Extensions{}
+	var parsed []ext.Extension
+	for {
+		tok, err := p.NextToken()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tok == xpp.EndDocument {
+			break
+		}
+		if tok == xpp.StartTag {
+			switch p.Name() {
+			case "event", "simple":
+				var e ext.Extension
+				var err error
+				extensions, e, err = ParseCustom(extensions, p)
+				if err != nil {
+					t.Fatal(err)
+				}
+				parsed = append(parsed, e)
+			}
+		}
+	}
+
+	if len(parsed) != 3 {
+		t.Fatalf("parsed %d elements, want 3", len(parsed))
+	}
+
+	// Nesting and attributes survive in the tree.
+	events := extensions[CustomPrefix]["event"]
+	if len(events) != 1 {
+		t.Fatalf("event entries = %d, want 1", len(events))
+	}
+	venue := events[0].Children["venue"][0]
+	if venue.Value != "Hall" || venue.Attrs["city"] != "Austin" {
+		t.Fatalf("venue = %+v", venue)
+	}
+
+	// Repetition appends rather than overwrites.
+	if n := len(extensions[CustomPrefix]["simple"]); n != 2 {
+		t.Fatalf("simple entries = %d, want 2", n)
+	}
+
+	// The returned element mirrors what was filed.
+	if parsed[0].Name != "event" || len(parsed[0].Children) != 1 {
+		t.Fatalf("returned element = %+v", parsed[0])
+	}
+	if parsed[1].Value != "plain" || len(parsed[1].Children) != 0 {
+		t.Fatalf("returned simple = %+v", parsed[1])
+	}
+}

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -178,10 +178,14 @@ func (rp *Parser) parseChannel(p *xpp.Parser) (rss *Feed, err error) {
 			rss.Image, err = rp.parseImage(p)
 		case "textinput":
 			rss.TextInput, err = rp.parseTextInput(p)
-		default:
-			// Skip element as it isn't an extension and not part of
-			// the spec.
+		case "items":
+			// The RSS 1.0 <items> rdf:Seq is a structural list of item
+			// references, not content; skip it rather than capture it.
 			err = p.Skip()
+		default:
+			// Not part of the spec: capture it into the extension map
+			// under the _custom pseudo namespace instead of dropping it.
+			extensions, _, err = shared.ParseCustom(extensions, p)
 		}
 		return err
 	})
@@ -227,6 +231,26 @@ func (rp *Parser) parseItem(p *xpp.Parser) (item *Item, err error) {
 	enclosures := []*Enclosure{}
 	links := []string{}
 
+	// captureCustom files an unrecognized child in the extension map under
+	// the _custom pseudo namespace, preserving nesting and attributes, and
+	// keeps the flat Custom map populated for elements without children so
+	// existing Custom reads are unchanged.
+	captureCustom := func(p *xpp.Parser) error {
+		var e ext.Extension
+		var err error
+		extensions, e, err = shared.ParseCustom(extensions, p)
+		if err != nil {
+			return err
+		}
+		if len(e.Children) == 0 {
+			if item.Custom == nil {
+				item.Custom = make(map[string]string)
+			}
+			item.Custom[e.Name] = shared.DecodeEntities(e.Value)
+		}
+		return nil
+	}
+
 	err = shared.ForEachChild(p, func(name string) error {
 		if shared.IsExtension(p) {
 			extensions, err = shared.ParseExtension(extensions, p)
@@ -242,7 +266,7 @@ func (rp *Parser) parseItem(p *xpp.Parser) (item *Item, err error) {
 			if shared.PrefixForNamespace(p.Space(), p) == "content" {
 				item.Content, err = shared.ParseText(p)
 			} else {
-				err = rp.parseItemCustom(p, item)
+				err = captureCustom(p)
 			}
 		case "link":
 			if item.Link, err = rp.parseLink(p); err == nil {
@@ -275,7 +299,7 @@ func (rp *Parser) parseItem(p *xpp.Parser) (item *Item, err error) {
 				categories = append(categories, cat)
 			}
 		default:
-			err = rp.parseItemCustom(p, item)
+			err = captureCustom(p)
 		}
 		return err
 	})
@@ -312,21 +336,6 @@ func (rp *Parser) parseItem(p *xpp.Parser) (item *Item, err error) {
 	}
 
 	return item, nil
-}
-
-// parseItemCustom stores an unrecognized item child in the Custom map,
-// keyed by its original-case name. Duplicate names keep the last value.
-func (rp *Parser) parseItemCustom(p *xpp.Parser, item *Item) error {
-	key := p.Name()
-	result, err := shared.ParseText(p)
-	if err != nil {
-		return err
-	}
-	if item.Custom == nil {
-		item.Custom = make(map[string]string)
-	}
-	item.Custom[key] = result
-	return nil
 }
 
 func (rp *Parser) parseLink(p *xpp.Parser) (url string, err error) {

--- a/testdata/parser/atom/atom10_feed_custom_elements.json
+++ b/testdata/parser/atom/atom10_feed_custom_elements.json
@@ -1,0 +1,40 @@
+{
+  "title": "Test Feed",
+  "id": "urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6",
+  "updated": "2003-12-13T18:30:02Z",
+  "updatedParsed": "2003-12-13T18:30:02Z",
+  "entries": [],
+  "extensions": {
+    "_custom": {
+      "customFeedId": [
+        {
+          "name": "customFeedId",
+          "value": "feed-123",
+          "attrs": {},
+          "children": {}
+        }
+      ],
+      "customMetadata": [
+        {
+          "name": "customMetadata",
+          "value": "Some metadata",
+          "attrs": {
+            "type": "internal"
+          },
+          "children": {}
+        }
+      ],
+      "updateInterval": [
+        {
+          "name": "updateInterval",
+          "value": "30",
+          "attrs": {
+            "units": "minutes"
+          },
+          "children": {}
+        }
+      ]
+    }
+  },
+  "version": "1.0"
+}

--- a/testdata/parser/atom/atom10_feed_custom_elements.xml
+++ b/testdata/parser/atom/atom10_feed_custom_elements.xml
@@ -1,0 +1,12 @@
+<!--
+Description: atom10 feed with custom elements at feed level
+-->
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Feed</title>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+  <updated>2003-12-13T18:30:02Z</updated>
+  <customFeedId>feed-123</customFeedId>
+  <updateInterval units="minutes">30</updateInterval>
+  <customMetadata type="internal">Some metadata</customMetadata>
+</feed>

--- a/testdata/parser/atom/atom10_feed_entry_custom_elements.json
+++ b/testdata/parser/atom/atom10_feed_entry_custom_elements.json
@@ -1,0 +1,45 @@
+{
+  "title": "Test Feed",
+  "id": "urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6",
+  "updated": "2003-12-13T18:30:02Z",
+  "updatedParsed": "2003-12-13T18:30:02Z",
+  "entries": [
+    {
+      "title": "Test Entry",
+      "id": "urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a",
+      "updated": "2003-12-13T18:30:02Z",
+      "updatedParsed": "2003-12-13T18:30:02Z",
+      "extensions": {
+        "_custom": {
+          "customId": [
+            {
+              "name": "customId",
+              "value": "entry-123",
+              "attrs": {},
+              "children": {}
+            }
+          ],
+          "customTag": [
+            {
+              "name": "customTag",
+              "value": "Custom Value",
+              "attrs": {},
+              "children": {}
+            }
+          ],
+          "priority": [
+            {
+              "name": "priority",
+              "value": "1",
+              "attrs": {
+                "level": "high"
+              },
+              "children": {}
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "version": "1.0"
+}

--- a/testdata/parser/atom/atom10_feed_entry_custom_elements.xml
+++ b/testdata/parser/atom/atom10_feed_entry_custom_elements.xml
@@ -1,0 +1,18 @@
+<!--
+Description: atom10 feed with custom elements at entry level
+-->
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Feed</title>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+  <updated>2003-12-13T18:30:02Z</updated>
+  
+  <entry>
+    <title>Test Entry</title>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+    <customId>entry-123</customId>
+    <priority level="high">1</priority>
+    <customTag>Custom Value</customTag>
+  </entry>
+</feed>

--- a/testdata/parser/atom/atom10_feed_entry_custom_multiple.json
+++ b/testdata/parser/atom/atom10_feed_entry_custom_multiple.json
@@ -1,0 +1,57 @@
+{
+  "title": "Test Feed",
+  "id": "urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6",
+  "updated": "2003-12-13T18:30:02Z",
+  "updatedParsed": "2003-12-13T18:30:02Z",
+  "entries": [
+    {
+      "title": "Test Entry",
+      "id": "urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a",
+      "updated": "2003-12-13T18:30:02Z",
+      "updatedParsed": "2003-12-13T18:30:02Z",
+      "extensions": {
+        "_custom": {
+          "keyword": [
+            {
+              "name": "keyword",
+              "value": "atom",
+              "attrs": {
+                "type": "primary"
+              },
+              "children": {}
+            },
+            {
+              "name": "keyword",
+              "value": "feed",
+              "attrs": {
+                "type": "secondary"
+              },
+              "children": {}
+            }
+          ],
+          "tag": [
+            {
+              "name": "tag",
+              "value": "First Tag",
+              "attrs": {},
+              "children": {}
+            },
+            {
+              "name": "tag",
+              "value": "Second Tag",
+              "attrs": {},
+              "children": {}
+            },
+            {
+              "name": "tag",
+              "value": "Third Tag",
+              "attrs": {},
+              "children": {}
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "version": "1.0"
+}

--- a/testdata/parser/atom/atom10_feed_entry_custom_multiple.xml
+++ b/testdata/parser/atom/atom10_feed_entry_custom_multiple.xml
@@ -1,0 +1,20 @@
+<!--
+Description: atom10 feed with multiple custom elements of same name
+-->
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Feed</title>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+  <updated>2003-12-13T18:30:02Z</updated>
+  
+  <entry>
+    <title>Test Entry</title>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+    <tag>First Tag</tag>
+    <tag>Second Tag</tag>
+    <tag>Third Tag</tag>
+    <keyword type="primary">atom</keyword>
+    <keyword type="secondary">feed</keyword>
+  </entry>
+</feed>

--- a/testdata/parser/atom/issue_275_extensions_and_source.json
+++ b/testdata/parser/atom/issue_275_extensions_and_source.json
@@ -19,6 +19,16 @@
           }
         ],
         "extensions": {
+          "_custom": {
+            "unknownsource": [
+              {
+                "name": "unknownsource",
+                "value": "z",
+                "attrs": {},
+                "children": {}
+              }
+            ]
+          },
           "dc": {
             "rights": [
               {
@@ -32,6 +42,16 @@
         }
       },
       "extensions": {
+        "_custom": {
+          "unknownentry": [
+            {
+              "name": "unknownentry",
+              "value": "y",
+              "attrs": {},
+              "children": {}
+            }
+          ]
+        },
         "dc": {
           "subject": [
             {
@@ -72,6 +92,16 @@
     }
   ],
   "extensions": {
+    "_custom": {
+      "unknownfeed": [
+        {
+          "name": "unknownfeed",
+          "value": "x",
+          "attrs": {},
+          "children": {}
+        }
+      ]
+    },
     "dc": {
       "creator": [
         {

--- a/testdata/parser/rss/issue_303_encoded_no_namespace.json
+++ b/testdata/parser/rss/issue_303_encoded_no_namespace.json
@@ -2,6 +2,18 @@
   "items": [
     {
       "title": "First",
+      "extensions": {
+        "_custom": {
+          "encoded": [
+            {
+              "name": "encoded",
+              "value": "hello",
+              "attrs": {},
+              "children": {}
+            }
+          ]
+        }
+      },
       "custom": {
         "encoded": "hello"
       }

--- a/testdata/parser/rss/rss_channel_custom_elements.json
+++ b/testdata/parser/rss/rss_channel_custom_elements.json
@@ -1,0 +1,35 @@
+{
+  "title": "Test Feed",
+  "extensions": {
+    "_custom": {
+      "customFeedId": [
+        {
+          "name": "customFeedId",
+          "value": "feed-123",
+          "attrs": {},
+          "children": {}
+        }
+      ],
+      "customMetadata": [
+        {
+          "name": "customMetadata",
+          "value": "Some metadata",
+          "attrs": {
+            "type": "internal"
+          },
+          "children": {}
+        }
+      ],
+      "updateFrequency": [
+        {
+          "name": "updateFrequency",
+          "value": "hourly",
+          "attrs": {},
+          "children": {}
+        }
+      ]
+    }
+  },
+  "items": [],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_custom_elements.xml
+++ b/testdata/parser/rss/rss_channel_custom_elements.xml
@@ -1,0 +1,11 @@
+<!--
+Description: rss channel with custom elements
+-->
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <customFeedId>feed-123</customFeedId>
+    <updateFrequency>hourly</updateFrequency>
+    <customMetadata type="internal">Some metadata</customMetadata>
+  </channel>
+</rss>

--- a/testdata/parser/rss/rss_channel_item_custom.json
+++ b/testdata/parser/rss/rss_channel_item_custom.json
@@ -1,6 +1,26 @@
 {
   "items": [
     {
+      "extensions": {
+        "_custom": {
+          "apcategory": [
+            {
+              "name": "apcategory",
+              "value": "s",
+              "attrs": {},
+              "children": {}
+            }
+          ],
+          "test": [
+            {
+              "name": "test",
+              "value": "test",
+              "attrs": {},
+              "children": {}
+            }
+          ]
+        }
+      },
       "custom": {
         "apcategory": "s",
         "test": "test"

--- a/testdata/parser/rss/rss_channel_item_custom_and_extension.json
+++ b/testdata/parser/rss/rss_channel_item_custom_and_extension.json
@@ -1,0 +1,45 @@
+{
+  "items": [
+    {
+      "title": "Test Item",
+      "extensions": {
+        "_custom": {
+          "customTag": [
+            {
+              "name": "customTag",
+              "value": "Custom Content",
+              "attrs": {},
+              "children": {}
+            }
+          ],
+          "internalId": [
+            {
+              "name": "internalId",
+              "value": "12345",
+              "attrs": {},
+              "children": {}
+            }
+          ]
+        },
+        "media": {
+          "content": [
+            {
+              "name": "content",
+              "value": "",
+              "attrs": {
+                "type": "image/jpeg",
+                "url": "http://example.com/media.jpg"
+              },
+              "children": {}
+            }
+          ]
+        }
+      },
+      "custom": {
+        "customTag": "Custom Content",
+        "internalId": "12345"
+      }
+    }
+  ],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_item_custom_and_extension.xml
+++ b/testdata/parser/rss/rss_channel_item_custom_and_extension.xml
@@ -1,0 +1,13 @@
+<!--
+Description: rss item with both custom elements and namespaced extensions
+-->
+<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <item>
+      <title>Test Item</title>
+      <customTag>Custom Content</customTag>
+      <media:content url="http://example.com/media.jpg" type="image/jpeg" />
+      <internalId>12345</internalId>
+    </item>
+  </channel>
+</rss>

--- a/testdata/parser/rss/rss_channel_item_custom_cdata.json
+++ b/testdata/parser/rss/rss_channel_item_custom_cdata.json
@@ -1,0 +1,31 @@
+{
+  "items": [
+    {
+      "extensions": {
+        "_custom": {
+          "htmlContent": [
+            {
+              "name": "htmlContent",
+              "value": "\u003cdiv\u003eSome \u003cb\u003eHTML\u003c/b\u003e content\u003c/div\u003e",
+              "attrs": {},
+              "children": {}
+            }
+          ],
+          "script": [
+            {
+              "name": "script",
+              "value": "function test() {\n          return \"Hello \u0026 \u003cWorld\u003e\";\n        }",
+              "attrs": {},
+              "children": {}
+            }
+          ]
+        }
+      },
+      "custom": {
+        "htmlContent": "\u003cdiv\u003eSome \u003cb\u003eHTML\u003c/b\u003e content\u003c/div\u003e",
+        "script": "function test() {\n          return \"Hello \u0026 \u003cWorld\u003e\";\n        }"
+      }
+    }
+  ],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_item_custom_cdata.xml
+++ b/testdata/parser/rss/rss_channel_item_custom_cdata.xml
@@ -1,0 +1,15 @@
+<!--
+Description: rss item with custom elements containing CDATA
+-->
+<rss version="2.0">
+  <channel>
+    <item>
+      <htmlContent><![CDATA[<div>Some <b>HTML</b> content</div>]]></htmlContent>
+      <script><![CDATA[
+        function test() {
+          return "Hello & <World>";
+        }
+      ]]></script>
+    </item>
+  </channel>
+</rss>

--- a/testdata/parser/rss/rss_channel_item_custom_multiple.json
+++ b/testdata/parser/rss/rss_channel_item_custom_multiple.json
@@ -1,0 +1,53 @@
+{
+  "items": [
+    {
+      "extensions": {
+        "_custom": {
+          "customId": [
+            {
+              "name": "customId",
+              "value": "123",
+              "attrs": {
+                "type": "primary"
+              },
+              "children": {}
+            },
+            {
+              "name": "customId",
+              "value": "456",
+              "attrs": {
+                "type": "secondary"
+              },
+              "children": {}
+            }
+          ],
+          "tag": [
+            {
+              "name": "tag",
+              "value": "First Tag",
+              "attrs": {},
+              "children": {}
+            },
+            {
+              "name": "tag",
+              "value": "Second Tag",
+              "attrs": {},
+              "children": {}
+            },
+            {
+              "name": "tag",
+              "value": "Third Tag",
+              "attrs": {},
+              "children": {}
+            }
+          ]
+        }
+      },
+      "custom": {
+        "customId": "456",
+        "tag": "Third Tag"
+      }
+    }
+  ],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_item_custom_multiple.xml
+++ b/testdata/parser/rss/rss_channel_item_custom_multiple.xml
@@ -1,0 +1,14 @@
+<!--
+Description: rss item with multiple custom elements of the same name
+-->
+<rss version="2.0">
+  <channel>
+    <item>
+      <tag>First Tag</tag>
+      <tag>Second Tag</tag>
+      <tag>Third Tag</tag>
+      <customId type="primary">123</customId>
+      <customId type="secondary">456</customId>
+    </item>
+  </channel>
+</rss>

--- a/testdata/parser/rss/rss_channel_item_custom_nested.json
+++ b/testdata/parser/rss/rss_channel_item_custom_nested.json
@@ -1,0 +1,49 @@
+{
+  "items": [
+    {
+      "extensions": {
+        "_custom": {
+          "event": [
+            {
+              "name": "event",
+              "value": "",
+              "attrs": {},
+              "children": {
+                "date": [
+                  {
+                    "name": "date",
+                    "value": "2026-07-04",
+                    "attrs": {},
+                    "children": {}
+                  }
+                ],
+                "venue": [
+                  {
+                    "name": "venue",
+                    "value": "The \u003cOld\u003e Hall",
+                    "attrs": {
+                      "city": "Austin"
+                    },
+                    "children": {}
+                  }
+                ]
+              }
+            }
+          ],
+          "simple": [
+            {
+              "name": "simple",
+              "value": "plain",
+              "attrs": {},
+              "children": {}
+            }
+          ]
+        }
+      },
+      "custom": {
+        "simple": "plain"
+      }
+    }
+  ],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_item_custom_nested.xml
+++ b/testdata/parser/rss/rss_channel_item_custom_nested.xml
@@ -1,0 +1,16 @@
+<!--
+Description: a nested custom element parses into the extension tree with
+children and CDATA text preserved; only childless elements reach the flat
+Custom map (issue #203)
+-->
+<rss version="2.0">
+  <channel>
+    <item>
+      <event>
+        <venue city="Austin"><![CDATA[The <Old> Hall]]></venue>
+        <date>2026-07-04</date>
+      </event>
+      <simple>plain</simple>
+    </item>
+  </channel>
+</rss>

--- a/testdata/parser/rss/rss_channel_item_custom_with_attrs.json
+++ b/testdata/parser/rss/rss_channel_item_custom_with_attrs.json
@@ -1,0 +1,37 @@
+{
+  "items": [
+    {
+      "extensions": {
+        "_custom": {
+          "customField": [
+            {
+              "name": "customField",
+              "value": "Custom Value",
+              "attrs": {
+                "id": "123",
+                "type": "special"
+              },
+              "children": {}
+            }
+          ],
+          "rating": [
+            {
+              "name": "rating",
+              "value": "8",
+              "attrs": {
+                "reviewer": "John",
+                "scale": "1-10"
+              },
+              "children": {}
+            }
+          ]
+        }
+      },
+      "custom": {
+        "customField": "Custom Value",
+        "rating": "8"
+      }
+    }
+  ],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_item_custom_with_attrs.xml
+++ b/testdata/parser/rss/rss_channel_item_custom_with_attrs.xml
@@ -1,0 +1,11 @@
+<!--
+Description: rss item with custom elements that have attributes
+-->
+<rss version="2.0">
+  <channel>
+    <item>
+      <customField id="123" type="special">Custom Value</customField>
+      <rating scale="1-10" reviewer="John">8</rating>
+    </item>
+  </channel>
+</rss>

--- a/testdata/translator/rss/feed_item_category_-_rss_channel_item_custom.json
+++ b/testdata/translator/rss/feed_item_category_-_rss_channel_item_custom.json
@@ -1,6 +1,26 @@
 {
   "items": [
     {
+      "extensions": {
+        "_custom": {
+          "apcategory": [
+            {
+              "name": "apcategory",
+              "value": "s",
+              "attrs": {},
+              "children": {}
+            }
+          ],
+          "test": [
+            {
+              "name": "test",
+              "value": "test",
+              "attrs": {},
+              "children": {}
+            }
+          ]
+        }
+      },
       "custom": {
         "apcategory": "s",
         "test": "test"


### PR DESCRIPTION
Fixes #276. Fixes #203. Fixes #82.

Unknown elements were handled three inconsistent ways: namespaced elements became the recursive `ext.Extension` tree, non-namespaced item children went into the flat `Item.Custom` map (dropping nesting, attributes and repetition, which is #203's corruption and #82's missing data), and unknown elements at channel level, atom feed, entry and source level were skipped and lost entirely.

This lands the #276 plan in its v1-additive form:

- `shared.ParseCustom` parses any unrecognized non-namespaced element with the same recursive builder namespaced extensions already use, and files it under the `_custom` pseudo namespace, preserving nesting, attributes and repetition. After #333 the capture point was one `default:` case per container, so the wiring is one line each in the rss channel/item and atom feed/entry/source parsers. The RSS 1.0 `<items>` rdf:Seq stays skipped: it is a structural list of item references, not content.
- `Item.Custom` stays as a compatibility shim fed from the tree. Childless elements keep their flat value exactly as before (entity-decoded, last one wins); nested elements no longer produce corrupted flat text, they live fully formed in the tree. The field is documented as deprecated in favor of the tree; removal waits for v2.
- `Feed` and `Item` gain `GetExtension`, `GetExtensionValue` and `GetCustomValue` accessors (the ergonomic layer from the old `v2-custom-elements` branch, adapted). That branch's parser approach was not used: it captured customs with flat `ParseText`, so it relocated the #203 corruption rather than fixing it.

Behavior notes: everything here is additive. Four existing fixtures gain `extensions._custom` blocks (82 added lines, zero removed or changed values, `custom` maps byte-identical). Data that was previously discarded (channel-level and atom-level unknowns) now appears in `Extensions`; feeds without unknown elements produce identical output.

Tests: nine new fixture pairs (channel-level customs, attributes, repetition, CDATA, nesting, custom-plus-extension mixes, atom feed and entry customs, and a nested-with-CDATA case reproducing #203) plus an accessor unit test covering namespaced lookups, feed and item custom values, repetition, nested children, the shim's childless-only contract, and absent-key behavior.
