### PR TITLE
Fix namespace handling for Atom extensions

### DIFF
--- a/atom/parser.go
+++ b/atom/parser.go
@@ -14,6 +14,14 @@ import (
 )
 
 var (
+	// nativeNamespaces identifies the official Atom vocabularies. The empty
+	// namespace admits elements from feeds that omit xmlns entirely.
+	nativeNamespaces = []string{
+		"",
+		shared.Atom10Namespace,
+		shared.Atom03Namespace,
+	}
+
 	// Atom elements which contain URIs
 	// https://tools.ietf.org/html/rfc4287
 	atomUriElements = map[string]bool{
@@ -58,7 +66,7 @@ func (ap *Parser) parseRoot(p *xpp.Parser) (*Feed, error) {
 	extensions := ext.Extensions{}
 
 	err := shared.ForEachChild(p, func(name string) error {
-		if shared.IsExtension(p) {
+		if shared.IsExtension(p, nativeNamespaces...) {
 			var err error
 			extensions, err = shared.ParseExtension(extensions, p)
 			return err
@@ -167,7 +175,7 @@ func (ap *Parser) parseEntry(p *xpp.Parser) (*Entry, error) {
 	extensions := ext.Extensions{}
 
 	err := shared.ForEachChild(p, func(name string) error {
-		if shared.IsExtension(p) {
+		if shared.IsExtension(p, nativeNamespaces...) {
 			var err error
 			extensions, err = shared.ParseExtension(extensions, p)
 			return err
@@ -264,7 +272,7 @@ func (ap *Parser) parseSource(p *xpp.Parser) (*Source, error) {
 	extensions := ext.Extensions{}
 
 	err := shared.ForEachChild(p, func(name string) error {
-		if shared.IsExtension(p) {
+		if shared.IsExtension(p, nativeNamespaces...) {
 			var err error
 			extensions, err = shared.ParseExtension(extensions, p)
 			return err
@@ -563,12 +571,12 @@ func (ap *Parser) parseVersion(p *xpp.Parser) string {
 		return ver
 	}
 
-	ns := p.Attribute("xmlns")
-	if ns == "http://purl.org/atom/ns#" {
+	ns := strings.TrimSpace(p.Space())
+	if ns == shared.Atom03Namespace {
 		return "0.3"
 	}
 
-	if ns == "http://www.w3.org/2005/Atom" {
+	if ns == shared.Atom10Namespace {
 		return "1.0"
 	}
 

--- a/internal/shared/extparser.go
+++ b/internal/shared/extparser.go
@@ -7,12 +7,31 @@ import (
 	xpp "github.com/mmcdole/goxpp/v2"
 )
 
-// IsExtension returns whether or not the current
-// XML element is an extension element (if it has a
-// non empty prefix)
-func IsExtension(p *xpp.Parser) bool {
-	prefix := PrefixForNamespace(p.Space(), p)
-	return !(prefix == "" || prefix == "rss" || prefix == "rdf" || prefix == "content")
+const (
+	Atom10Namespace   = "http://www.w3.org/2005/Atom"
+	Atom03Namespace   = "http://purl.org/atom/ns#"
+	RDFNamespace      = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	RSS10Namespace    = "http://purl.org/rss/1.0/"
+	RSS09Namespace    = "http://channel.netscape.com/rdf/simple/0.9/"
+	RSS09AltNamespace = "http://my.netscape.com/rdf/simple/0.9/"
+)
+
+// InNamespace reports whether the current element's resolved namespace is
+// one of namespaces.
+func InNamespace(p *xpp.Parser, namespaces ...string) bool {
+	space := strings.TrimSpace(p.Space())
+	for _, namespace := range namespaces {
+		if space == namespace {
+			return true
+		}
+	}
+	return false
+}
+
+// IsExtension reports whether the current element is outside the native
+// namespaces supplied by the format parser.
+func IsExtension(p *xpp.Parser, nativeNamespaces ...string) bool {
+	return !InNamespace(p, nativeNamespaces...)
 }
 
 // ParseExtension parses the current element of the
@@ -90,9 +109,7 @@ func parseExtensionElement(p *xpp.Parser) (e ext.Extension, err error) {
 }
 
 func PrefixForNamespace(space string, p *xpp.Parser) string {
-	// Namespace attribute values may legally carry surrounding whitespace.
-	// Trim here, once, so every lookup below (and every caller) agrees on
-	// the key.
+	// Namespace URI comparisons ignore surrounding whitespace in declarations.
 	space = strings.TrimSpace(space)
 
 	// First we check if the global namespace map
@@ -105,13 +122,13 @@ func PrefixForNamespace(space string, p *xpp.Parser) string {
 
 	// Next we check if the feed itself declared a prefix for this
 	// namespace and return it if we have a result.
-	if prefix, ok := p.PrefixForURI(space); ok {
+	if prefix, ok := p.PrefixForURI(space); ok && prefix != "" {
 		return prefix
 	}
 
-	// Lastly, any namespace which is not defined in the
-	// the feed will be the prefix itself when using Go's
-	// xml.Decoder.Token() method.
+	// Fall back to the value itself: a namespace bound only as the default
+	// yields its URI (a non-empty, collision-free key), and an undeclared
+	// prefix arrives in Space as the raw prefix and maps to itself.
 	return space
 }
 
@@ -121,6 +138,9 @@ func PrefixForNamespace(space string, p *xpp.Parser) string {
 //
 // These canonical prefixes override any prefixes used in the feed itself.
 var canonicalNamespaces = map[string]string{
+	Atom10Namespace: "atom",
+	Atom03Namespace: "atom03",
+
 	"http://webns.net/mvcb/":                                         "admin",
 	"http://purl.org/rss/1.0/modules/aggregation/":                   "ag",
 	"http://purl.org/rss/1.0/modules/annotate/":                      "annotate",

--- a/internal/shared/extparser_test.go
+++ b/internal/shared/extparser_test.go
@@ -41,15 +41,27 @@ func TestIsExtension(t *testing.T) {
 		element string
 		want    bool
 	}{
-		{"title", false},   // no prefix
-		{"author", true},   // itunes prefix
-		{"encoded", false}, // content prefix is exempt
+		{"title", false},  // no namespace
+		{"author", true},  // iTunes namespace
+		{"encoded", true}, // content namespace
 	}
 	for _, c := range cases {
 		p := parserOn(t, doc, c.element)
-		if got := IsExtension(p); got != c.want {
+		if got := IsExtension(p, ""); got != c.want {
 			t.Errorf("IsExtension(<%s>) = %v, want %v", c.element, got, c.want)
 		}
+	}
+}
+
+func TestIsExtensionUsesResolvedNamespace(t *testing.T) {
+	doc := `<rss xmlns:a="http://www.w3.org/2005/Atom"><channel><a:link/></channel></rss>`
+	p := parserOn(t, doc, "link")
+
+	if IsExtension(p, Atom10Namespace) {
+		t.Error("Atom namespace should be native when the Atom parser supplies it")
+	}
+	if !IsExtension(p, "") {
+		t.Error("Atom namespace should be an extension when the RSS parser supplies only its native namespace")
 	}
 }
 
@@ -75,7 +87,7 @@ func TestParseExtension(t *testing.T) {
 		if tok == xpp.EndDocument {
 			break
 		}
-		if tok == xpp.StartTag && IsExtension(p) {
+		if tok == xpp.StartTag && IsExtension(p, "") {
 			extensions, err = ParseExtension(extensions, p)
 			if err != nil {
 				t.Fatal(err)
@@ -107,8 +119,8 @@ func TestParseExtension(t *testing.T) {
 }
 
 func TestPrefixForNamespace(t *testing.T) {
-	doc := `<rss xmlns:pod="http://www.itunes.com/DTDs/PodCast-1.0.dtd" xmlns:custom="http://example.org/ns">
-		<channel><pod:author>a</pod:author></channel>
+	doc := `<rss xmlns:pod="http://www.itunes.com/DTDs/PodCast-1.0.dtd" xmlns:custom="http://example.org/ns" xmlns:a="http://www.w3.org/2005/Atom" xmlns:legacy="http://purl.org/atom/ns#">
+		<channel><pod:author>a</pod:author><a:link/><legacy:link/></channel>
 	</rss>`
 	p := parserOn(t, doc, "author")
 
@@ -129,6 +141,17 @@ func TestPrefixForNamespace(t *testing.T) {
 	// Space; it maps to itself.
 	if got := PrefixForNamespace("media", p); got != "media" {
 		t.Errorf("undeclared = %q, want media", got)
+	}
+	atom := parserOn(t, doc, "link")
+	if got := PrefixForNamespace(Atom10Namespace, atom); got != "atom" {
+		t.Errorf("Atom canonical = %q, want atom", got)
+	}
+	if got := PrefixForNamespace(Atom03Namespace, atom); got != "atom03" {
+		t.Errorf("Atom 0.3 canonical = %q, want atom03", got)
+	}
+	defaultOnly := parserOn(t, `<root><value xmlns="urn:example"/></root>`, "value")
+	if got := PrefixForNamespace("urn:example", defaultOnly); got != "urn:example" {
+		t.Errorf("default namespace = %q, want urn:example", got)
 	}
 }
 

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -11,6 +11,17 @@ import (
 	xpp "github.com/mmcdole/goxpp/v2"
 )
 
+// nativeNamespaces identifies the RSS and RDF vocabularies handled directly.
+var nativeNamespaces = []string{
+	"",
+	"rss", // undeclared prefixes are surfaced literally by encoding/xml
+	"rdf",
+	shared.RDFNamespace,
+	shared.RSS10Namespace,
+	shared.RSS09Namespace,
+	shared.RSS09AltNamespace,
+}
+
 // Parser is a RSS Parser
 type Parser struct{}
 
@@ -44,7 +55,7 @@ func (rp *Parser) parseRoot(p *xpp.Parser) (*Feed, error) {
 
 	err := shared.ForEachChild(p, func(name string) error {
 		// Skip any extensions found in the feed root.
-		if shared.IsExtension(p) {
+		if shared.IsExtension(p, nativeNamespaces...) {
 			return p.Skip()
 		}
 		var err error
@@ -120,7 +131,7 @@ func (rp *Parser) parseChannel(p *xpp.Parser) (rss *Feed, err error) {
 	}
 
 	err = shared.ForEachChild(p, func(name string) error {
-		if shared.IsExtension(p) {
+		if shared.IsExtension(p, nativeNamespaces...) {
 			extensions, err = shared.ParseExtension(extensions, p)
 			return err
 		}
@@ -228,22 +239,24 @@ func (rp *Parser) parseItem(p *xpp.Parser) (item *Item, err error) {
 	links := []string{}
 
 	err = shared.ForEachChild(p, func(name string) error {
-		if shared.IsExtension(p) {
+		var err error
+		// content:encoded is foreign to RSS but maps to item.Content; it must be
+		// claimed here or the extension routing below swallows it.
+		if name == "encoded" && shared.PrefixForNamespace(p.Space(), p) == "content" {
+			item.Content, err = shared.ParseText(p)
+			return err
+		}
+		if shared.IsExtension(p, nativeNamespaces...) {
 			extensions, err = shared.ParseExtension(extensions, p)
 			return err
 		}
-		var err error
 		switch name {
 		case "title":
 			item.Title, err = shared.ParseText(p)
 		case "description":
 			item.Description, err = shared.ParseText(p)
 		case "encoded":
-			if shared.PrefixForNamespace(p.Space(), p) == "content" {
-				item.Content, err = shared.ParseText(p)
-			} else {
-				err = rp.parseItemCustom(p, item)
-			}
+			err = rp.parseItemCustom(p, item)
 		case "link":
 			if item.Link, err = rp.parseLink(p); err == nil {
 				links = append(links, item.Link)
@@ -598,12 +611,29 @@ func (rp *Parser) parseVersion(p *xpp.Parser) (ver string) {
 	if name == "rss" {
 		ver = p.Attribute("version")
 	} else if name == "rdf" {
-		ns := p.Attribute("xmlns")
-		if ns == "http://channel.netscape.com/rdf/simple/0.9/" ||
-			ns == "http://my.netscape.com/rdf/simple/0.9/" {
-			ver = "0.9"
-		} else if ns == "http://purl.org/rss/1.0/" {
-			ver = "1.0"
+		// RSS 0.9 and 1.0 are RDF vocabularies. Their namespace may use
+		// either the default binding or any document-defined prefix.
+		namespaces := p.Namespaces()
+		defaultNamespace := strings.TrimSpace(namespaces[""])
+		known := []struct {
+			namespace string
+			version   string
+		}{
+			{shared.RSS10Namespace, "1.0"},
+			{shared.RSS09Namespace, "0.9"},
+			{shared.RSS09AltNamespace, "0.9"},
+		}
+		for _, candidate := range known {
+			if defaultNamespace == candidate.namespace {
+				return candidate.version
+			}
+		}
+		for _, candidate := range known {
+			for prefix, namespace := range namespaces {
+				if prefix != "" && strings.TrimSpace(namespace) == candidate.namespace {
+					return candidate.version
+				}
+			}
 		}
 	}
 	return

--- a/testdata/parser/atom/atom03_feed_namespace_prefixed.json
+++ b/testdata/parser/atom/atom03_feed_namespace_prefixed.json
@@ -1,0 +1,15 @@
+{
+  "title": "Feed",
+  "links": [
+    {
+      "href": "https://example.org/feed",
+      "rel": "self"
+    }
+  ],
+  "entries": [
+    {
+      "title": "Entry"
+    }
+  ],
+  "version": "0.3"
+}

--- a/testdata/parser/atom/atom03_feed_namespace_prefixed.xml
+++ b/testdata/parser/atom/atom03_feed_namespace_prefixed.xml
@@ -1,0 +1,11 @@
+<!--
+Description: a prefixed-only Atom 0.3 document uses its namespace URI for
+native element detection and version identification.
+-->
+<a:feed xmlns:a="http://purl.org/atom/ns#">
+  <a:title>Feed</a:title>
+  <a:link href="https://example.org/feed" rel="self"/>
+  <a:entry>
+    <a:title>Entry</a:title>
+  </a:entry>
+</a:feed>

--- a/testdata/parser/atom/atom10_feed_namespace_dual_default_first.json
+++ b/testdata/parser/atom/atom10_feed_namespace_dual_default_first.json
@@ -1,0 +1,18 @@
+{
+  "title": "Feed",
+  "links": [
+    {
+      "href": "https://example.org/feed",
+      "rel": "self"
+    }
+  ],
+  "entries": [
+    {
+      "title": "Entry",
+      "source": {
+        "title": "Source"
+      }
+    }
+  ],
+  "version": "1.0"
+}

--- a/testdata/parser/atom/atom10_feed_namespace_dual_default_first.xml
+++ b/testdata/parser/atom/atom10_feed_namespace_dual_default_first.xml
@@ -1,0 +1,14 @@
+<!--
+Description: Atom elements remain native when the Atom namespace has both a
+default and a prefixed binding, regardless of declaration order.
+-->
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:atom="http://www.w3.org/2005/Atom">
+  <title>Feed</title>
+  <link href="https://example.org/feed" rel="self"/>
+  <entry>
+    <title>Entry</title>
+    <source>
+      <title>Source</title>
+    </source>
+  </entry>
+</feed>

--- a/testdata/parser/atom/atom10_feed_namespace_dual_prefix_first.json
+++ b/testdata/parser/atom/atom10_feed_namespace_dual_prefix_first.json
@@ -1,0 +1,18 @@
+{
+  "title": "Feed",
+  "links": [
+    {
+      "href": "https://example.org/feed",
+      "rel": "self"
+    }
+  ],
+  "entries": [
+    {
+      "title": "Entry",
+      "source": {
+        "title": "Source"
+      }
+    }
+  ],
+  "version": "1.0"
+}

--- a/testdata/parser/atom/atom10_feed_namespace_dual_prefix_first.xml
+++ b/testdata/parser/atom/atom10_feed_namespace_dual_prefix_first.xml
@@ -1,0 +1,14 @@
+<!--
+Description: Atom elements remain native when the Atom namespace has both a
+prefixed and a default binding, regardless of declaration order.
+-->
+<feed xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://www.w3.org/2005/Atom">
+  <title>Feed</title>
+  <link href="https://example.org/feed" rel="self"/>
+  <entry>
+    <title>Entry</title>
+    <source>
+      <title>Source</title>
+    </source>
+  </entry>
+</feed>

--- a/testdata/parser/atom/atom10_feed_namespace_prefixed.json
+++ b/testdata/parser/atom/atom10_feed_namespace_prefixed.json
@@ -1,0 +1,30 @@
+{
+  "title": "Feed",
+  "links": [
+    {
+      "href": "https://example.org/feed",
+      "rel": "self"
+    }
+  ],
+  "entries": [
+    {
+      "title": "Entry",
+      "source": {
+        "title": "Source"
+      }
+    }
+  ],
+  "extensions": {
+    "content": {
+      "title": [
+        {
+          "name": "title",
+          "value": "Foreign",
+          "attrs": {},
+          "children": {}
+        }
+      ]
+    }
+  },
+  "version": "1.0"
+}

--- a/testdata/parser/atom/atom10_feed_namespace_prefixed.xml
+++ b/testdata/parser/atom/atom10_feed_namespace_prefixed.xml
@@ -1,0 +1,16 @@
+<!--
+Description: a prefixed-only Atom 1.0 document uses its namespace URI for
+native element detection while foreign elements with the same local name stay
+in Extensions.
+-->
+<atom:feed xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <atom:title>Feed</atom:title>
+  <content:title>Foreign</content:title>
+  <atom:link href="https://example.org/feed" rel="self"/>
+  <atom:entry>
+    <atom:title>Entry</atom:title>
+    <atom:source>
+      <atom:title>Source</atom:title>
+    </atom:source>
+  </atom:entry>
+</atom:feed>

--- a/testdata/parser/rss/issue_338_atom_link_namespace.json
+++ b/testdata/parser/rss/issue_338_atom_link_namespace.json
@@ -1,0 +1,36 @@
+{
+  "title": "Conan O’Brien Needs A Friend",
+  "link": "https://www.siriusxm.com",
+  "links": [
+    "https://www.siriusxm.com"
+  ],
+  "extensions": {
+    "atom": {
+      "link": [
+        {
+          "name": "link",
+          "value": "",
+          "attrs": {
+            "href": "https://feeds.simplecast.com/dHoohVNH",
+            "rel": "self",
+            "title": "MP3 Audio",
+            "type": "application/atom+xml"
+          },
+          "children": {}
+        },
+        {
+          "name": "link",
+          "value": "",
+          "attrs": {
+            "href": "https://simplecast.superfeedr.com",
+            "rel": "hub",
+            "xmlns": "http://www.w3.org/2005/Atom"
+          },
+          "children": {}
+        }
+      ]
+    }
+  },
+  "items": [],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/issue_338_atom_link_namespace.xml
+++ b/testdata/parser/rss/issue_338_atom_link_namespace.xml
@@ -1,0 +1,13 @@
+<!--
+Description: the reporter's Atom hub link uses a redundant local default
+namespace and must remain available under Extensions["atom"]["link"]
+(issue #338).
+-->
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <atom:link href="https://feeds.simplecast.com/dHoohVNH" rel="self" title="MP3 Audio" type="application/atom+xml"/>
+    <atom:link href="https://simplecast.superfeedr.com" rel="hub" xmlns="http://www.w3.org/2005/Atom"/>
+    <title>Conan O’Brien Needs A Friend</title>
+    <link>https://www.siriusxm.com</link>
+  </channel>
+</rss>

--- a/testdata/parser/rss/rss_channel_atom_link_namespace_bindings.json
+++ b/testdata/parser/rss/rss_channel_atom_link_namespace_bindings.json
@@ -1,0 +1,42 @@
+{
+  "extensions": {
+    "atom": {
+      "link": [
+        {
+          "name": "link",
+          "value": "",
+          "attrs": {
+            "href": "https://hub.example.org/atom-prefix",
+            "rel": "hub"
+          },
+          "children": {}
+        },
+        {
+          "name": "link",
+          "value": "",
+          "attrs": {
+            "href": "https://hub.example.org/default-namespace",
+            "rel": "hub",
+            "xmlns": "http://www.w3.org/2005/Atom"
+          },
+          "children": {}
+        }
+      ]
+    },
+    "atom03": {
+      "link": [
+        {
+          "name": "link",
+          "value": "",
+          "attrs": {
+            "href": "https://hub.example.org/atom03-prefix",
+            "rel": "hub"
+          },
+          "children": {}
+        }
+      ]
+    }
+  },
+  "items": [],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_atom_link_namespace_bindings.xml
+++ b/testdata/parser/rss/rss_channel_atom_link_namespace_bindings.xml
@@ -1,0 +1,11 @@
+<!--
+Description: Atom extensions embedded in RSS use canonical extension keys for
+arbitrary prefixes and locally declared default namespaces.
+-->
+<rss version="2.0" xmlns:a="http://www.w3.org/2005/Atom" xmlns:legacy="http://purl.org/atom/ns#">
+  <channel>
+    <a:link href="https://hub.example.org/atom-prefix" rel="hub"/>
+    <link xmlns="http://www.w3.org/2005/Atom" href="https://hub.example.org/default-namespace" rel="hub"/>
+    <legacy:link href="https://hub.example.org/atom03-prefix" rel="hub"/>
+  </channel>
+</rss>

--- a/testdata/parser/rss/rss_channel_item_content_encoded_variant_namespace.json
+++ b/testdata/parser/rss/rss_channel_item_content_encoded_variant_namespace.json
@@ -1,0 +1,8 @@
+{
+  "items": [
+    {
+      "content": "Body"
+    }
+  ],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/rss_channel_item_content_encoded_variant_namespace.xml
+++ b/testdata/parser/rss/rss_channel_item_content_encoded_variant_namespace.xml
@@ -1,0 +1,11 @@
+<!--
+Description: content:encoded remains Item.Content when a feed declares the
+commonly seen content module URI variant without its trailing slash.
+-->
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content">
+  <channel>
+    <item>
+      <content:encoded>Body</content:encoded>
+    </item>
+  </channel>
+</rss>

--- a/testdata/parser/rss/version_rdf_090.json
+++ b/testdata/parser/rss/version_rdf_090.json
@@ -1,4 +1,5 @@
 {
+    "title": "Feed",
     "items": [],
     "version": "0.9"
 }

--- a/testdata/parser/rss/version_rdf_090.xml
+++ b/testdata/parser/rss/version_rdf_090.xml
@@ -2,4 +2,7 @@
 <rdf:RDF
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns="http://channel.netscape.com/rdf/simple/0.9/">
+  <channel>
+    <title>Feed</title>
+  </channel>
 </rdf:RDF>

--- a/testdata/parser/rss/version_rdf_090_alternate_namespace.json
+++ b/testdata/parser/rss/version_rdf_090_alternate_namespace.json
@@ -1,0 +1,5 @@
+{
+  "title": "Feed",
+  "items": [],
+  "version": "0.9"
+}

--- a/testdata/parser/rss/version_rdf_090_alternate_namespace.xml
+++ b/testdata/parser/rss/version_rdf_090_alternate_namespace.xml
@@ -1,0 +1,9 @@
+<!--
+Description: RSS 0.90 recognizes the alternate Netscape namespace as its
+native vocabulary.
+-->
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://my.netscape.com/rdf/simple/0.9/">
+  <channel>
+    <title>Feed</title>
+  </channel>
+</rdf:RDF>

--- a/testdata/parser/rss/version_rdf_10_prefixed_namespace.json
+++ b/testdata/parser/rss/version_rdf_10_prefixed_namespace.json
@@ -1,0 +1,9 @@
+{
+  "title": "Feed",
+  "items": [
+    {
+      "title": "Entry"
+    }
+  ],
+  "version": "1.0"
+}

--- a/testdata/parser/rss/version_rdf_10_prefixed_namespace.xml
+++ b/testdata/parser/rss/version_rdf_10_prefixed_namespace.xml
@@ -1,0 +1,12 @@
+<!--
+Description: RSS 1.0 native elements and version detection use the namespace
+URI when the RSS vocabulary has a document-defined prefix.
+-->
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:r="http://purl.org/rss/1.0/">
+  <r:channel>
+    <r:title>Feed</r:title>
+  </r:channel>
+  <r:item>
+    <r:title>Entry</r:title>
+  </r:item>
+</rdf:RDF>

--- a/testdata/translator/rss/issue_338_atom_link_namespace.json
+++ b/testdata/translator/rss/issue_338_atom_link_namespace.json
@@ -1,0 +1,39 @@
+{
+  "title": "Conan O’Brien Needs A Friend",
+  "link": "https://www.siriusxm.com",
+  "feedLink": "https://feeds.simplecast.com/dHoohVNH",
+  "links": [
+    "https://www.siriusxm.com",
+    "https://feeds.simplecast.com/dHoohVNH"
+  ],
+  "extensions": {
+    "atom": {
+      "link": [
+        {
+          "name": "link",
+          "value": "",
+          "attrs": {
+            "href": "https://feeds.simplecast.com/dHoohVNH",
+            "rel": "self",
+            "title": "MP3 Audio",
+            "type": "application/atom+xml"
+          },
+          "children": {}
+        },
+        {
+          "name": "link",
+          "value": "",
+          "attrs": {
+            "href": "https://simplecast.superfeedr.com",
+            "rel": "hub",
+            "xmlns": "http://www.w3.org/2005/Atom"
+          },
+          "children": {}
+        }
+      ]
+    }
+  },
+  "items": [],
+  "feedType": "rss",
+  "feedVersion": "2.0"
+}

--- a/testdata/translator/rss/issue_338_atom_link_namespace.xml
+++ b/testdata/translator/rss/issue_338_atom_link_namespace.xml
@@ -1,0 +1,12 @@
+<!--
+Description: the reporter's Atom hub link uses a redundant local default
+namespace and remains in the universal feed's Atom extensions (issue #338).
+-->
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <atom:link href="https://feeds.simplecast.com/dHoohVNH" rel="self" title="MP3 Audio" type="application/atom+xml"/>
+    <atom:link href="https://simplecast.superfeedr.com" rel="hub" xmlns="http://www.w3.org/2005/Atom"/>
+    <title>Conan O’Brien Needs A Friend</title>
+    <link>https://www.siriusxm.com</link>
+  </channel>
+</rss>


### PR DESCRIPTION
This fixes namespace handling for Atom elements inside RSS feeds.

The feed from #338 declares its hub link with a local Atom default namespace. The parser previously treated that link as a normal RSS link, which lost its `rel="hub"` meaning. The link now remains available through `Feed.Extensions["atom"]["link"]`, alongside the feed's self link.

Namespace matching now uses namespace URIs instead of the prefixes chosen by each feed. This also makes prefixed Atom and RDF feeds behave consistently while keeping the existing `content:encoded` compatibility.

The tests use parser and translator fixture pairs, including the feed shape from #338.

Fixes #338
