### PR TITLE
Preserve author URLs in the universal feed

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -86,11 +86,11 @@ type Item struct {
 
 // Person is an individual specified in a feed
 // (e.g. an author)
-// to support uri
 type Person struct {
 	Name  string `json:"name,omitempty"`
 	Email string `json:"email,omitempty"`
-	URI   string `json:"uri,omitempty"`
+	// URL is an address associated with the person, including Atom URI references.
+	URL string `json:"url,omitempty"`
 }
 
 // Image is an image that is the artwork for a given

--- a/feed.go
+++ b/feed.go
@@ -86,9 +86,11 @@ type Item struct {
 
 // Person is an individual specified in a feed
 // (e.g. an author)
+// to support uri
 type Person struct {
 	Name  string `json:"name,omitempty"`
 	Email string `json:"email,omitempty"`
+	URI   string `json:"uri,omitempty"`
 }
 
 // Image is an image that is the artwork for a given

--- a/testdata/translator/atom/issue_200_author_url.json
+++ b/testdata/translator/atom/issue_200_author_url.json
@@ -1,0 +1,44 @@
+{
+  "author": {
+    "name": "Feed Author",
+    "email": "author@example.org",
+    "url": "https://example.org/authors/feed"
+  },
+  "authors": [
+    {
+      "name": "Feed Author",
+      "email": "author@example.org",
+      "url": "https://example.org/authors/feed"
+    },
+    {
+      "name": "Without URL"
+    },
+    {
+      "name": "Identifier",
+      "url": "urn:example:author"
+    }
+  ],
+  "feedType": "atom",
+  "feedVersion": "1.0",
+  "items": [
+    {
+      "author": {
+        "name": "Entry Author",
+        "url": "https://other.example/author"
+      },
+      "authors": [
+        {
+          "name": "Entry Author",
+          "url": "https://other.example/author"
+        },
+        {
+          "name": "Relative Author",
+          "url": "https://example.org/people/entry"
+        },
+        {
+          "name": "Without URL"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/translator/atom/issue_200_author_url.xml
+++ b/testdata/translator/atom/issue_200_author_url.xml
@@ -1,0 +1,11 @@
+<!-- Preserve feed and entry author addresses, including relative and non-HTTP URIs. -->
+<feed xmlns="http://www.w3.org/2005/Atom" xml:base="https://example.org/">
+  <author><name>Feed Author</name><email>author@example.org</email><uri>authors/feed</uri></author>
+  <author><name>Without URL</name></author>
+  <author><name>Identifier</name><uri>urn:example:author</uri></author>
+  <entry>
+    <author><name>Entry Author</name><uri>https://other.example/author</uri></author>
+    <author xml:base="people/"><name>Relative Author</name><uri>entry</uri></author>
+    <author><name>Without URL</name></author>
+  </entry>
+</feed>

--- a/translator.go
+++ b/translator.go
@@ -679,7 +679,7 @@ func atomPersons(persons []*atom.Person) []*Person {
 	}
 	out := make([]*Person, 0, len(persons))
 	for _, p := range persons {
-		out = append(out, &Person{Name: p.Name, Email: p.Email, URI: p.URI})
+		out = append(out, &Person{Name: p.Name, Email: p.Email, URL: p.URI})
 	}
 	return out
 }
@@ -741,7 +741,7 @@ func (t *DefaultJSONTranslator) Translate(feed interface{}) (*Feed, error) {
 	}
 
 	if jsonFeed.Author != nil {
-		result.Author = personFromText(jsonFeed.Author.Name)
+		result.Author = jsonPerson(jsonFeed.Author)
 	}
 	if jsonFeed.Authors != nil {
 		result.Authors = jsonPersons(jsonFeed.Authors)
@@ -815,7 +815,7 @@ func (t *DefaultJSONTranslator) translateFeedItem(jsonItem *json.Item) *Item {
 	}
 
 	if jsonItem.Author != nil {
-		item.Author = personFromText(jsonItem.Author.Name)
+		item.Author = jsonPerson(jsonItem.Author)
 	}
 	if jsonItem.Authors != nil {
 		item.Authors = jsonPersons(jsonItem.Authors)
@@ -844,7 +844,7 @@ func (t *DefaultJSONTranslator) translateFeedItem(jsonItem *json.Item) *Item {
 
 	// TODO ExternalURL is missing in global Feed
 	// TODO BannerImage is missing in global Feed
-	// Author.URL and Author.Avatar are missing in global feed
+	// Author.Avatar is missing in global feed
 	return item
 }
 
@@ -853,7 +853,14 @@ func (t *DefaultJSONTranslator) translateFeedItem(jsonItem *json.Item) *Item {
 func jsonPersons(authors []*json.Author) []*Person {
 	out := make([]*Person, 0, len(authors))
 	for _, a := range authors {
-		out = append(out, personFromText(a.Name))
+		out = append(out, jsonPerson(a))
 	}
 	return out
+}
+
+// jsonPerson preserves the author URL alongside the parsed name and email.
+func jsonPerson(author *json.Author) *Person {
+	person := personFromText(author.Name)
+	person.URL = author.URL
+	return person
 }

--- a/translator.go
+++ b/translator.go
@@ -679,7 +679,7 @@ func atomPersons(persons []*atom.Person) []*Person {
 	}
 	out := make([]*Person, 0, len(persons))
 	for _, p := range persons {
-		out = append(out, &Person{Name: p.Name, Email: p.Email})
+		out = append(out, &Person{Name: p.Name, Email: p.Email, URI: p.URI})
 	}
 	return out
 }

--- a/translator_test.go
+++ b/translator_test.go
@@ -268,35 +268,21 @@ func TestDisableContentImageScan(t *testing.T) {
 	assert.Nil(t, out.Items[0].Image)
 }
 
-// test translate person uri
-func TestPersonURI(t *testing.T) {
-	feeds := []struct {
-		name string
-		data string
-		want string
+func TestPersonURLJSON(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		person gofeed.Person
+		want   string
 	}{
-		{name: "xml", data: `<feed xmlns="http://www.w3.org/2005/Atom"> <title>Daring Fireball</title><author><name>John Gruber</name>
-	 <uri>http://daringfireball.net/</uri></author> </feed>`,
-			want: "http://daringfireball.net/",
-		},
-	}
-	for _, tt := range feeds {
+		{name: "present", person: gofeed.Person{Name: "Author", URL: "https://example.org/author"}, want: `{"name":"Author","url":"https://example.org/author"}`},
+		{name: "absent", person: gofeed.Person{Name: "Author"}, want: `{"name":"Author"}`},
+	} {
 		t.Run(tt.name, func(t *testing.T) {
-			fp := &atom.Parser{}
-			atom, err := fp.Parse(strings.NewReader(tt.data))
+			got, err := jsonEncoding.Marshal(tt.person)
 			if err != nil {
-				t.Errorf("error %v", err)
-				return
+				t.Fatal(err)
 			}
-			def := gofeed.DefaultAtomTranslator{}
-			feed, err := def.Translate(atom)
-			for _, p := range feed.Authors {
-				if p.URI != tt.want {
-					t.Errorf("test fail %v", p.URI)
-				} else {
-					t.Logf("test pass ")
-				}
-			}
+			assert.JSONEq(t, tt.want, string(got))
 		})
 	}
 }

--- a/translator_test.go
+++ b/translator_test.go
@@ -267,3 +267,36 @@ func TestDisableContentImageScan(t *testing.T) {
 	assert.Nil(t, out.Image)
 	assert.Nil(t, out.Items[0].Image)
 }
+
+// test translate person uri
+func TestPersonURI(t *testing.T) {
+	feeds := []struct {
+		name string
+		data string
+		want string
+	}{
+		{name: "xml", data: `<feed xmlns="http://www.w3.org/2005/Atom"> <title>Daring Fireball</title><author><name>John Gruber</name>
+	 <uri>http://daringfireball.net/</uri></author> </feed>`,
+			want: "http://daringfireball.net/",
+		},
+	}
+	for _, tt := range feeds {
+		t.Run(tt.name, func(t *testing.T) {
+			fp := &atom.Parser{}
+			atom, err := fp.Parse(strings.NewReader(tt.data))
+			if err != nil {
+				t.Errorf("error %v", err)
+				return
+			}
+			def := gofeed.DefaultAtomTranslator{}
+			feed, err := def.Translate(atom)
+			for _, p := range feed.Authors {
+				if p.URI != tt.want {
+					t.Errorf("test fail %v", p.URI)
+				} else {
+					t.Logf("test pass ")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Preserve author addresses that were parsed but discarded during translation into the universal feed. Add `Person.URL` (`url` in JSON), mapping Atom person URIs and JSON Feed 1.0/1.1 author URLs at feed and item level.

Add an Atom translator fixture covering multiple authors, relative addresses, non-HTTP URIs, missing addresses, and the legacy singular author fields. Check JSON serialization of present and absent URLs; the existing JSON Feed fixtures cover author URL translation.

Validated with build, vet, Staticcheck, and the race-enabled shuffled test suite.

Fixes #200.
