### PR TITLE
Clearer error when the response is an HTML page, not a feed

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -126,7 +126,62 @@ func (f *Parser) Parse(feed io.Reader) (*Feed, error) {
 		return f.parseJSONFeed(br)
 	}
 
+	// When the input isn't a recognizable feed the most common cause is that
+	// the response wasn't a feed at all — an HTML login wall, error page, or
+	// bot-protection challenge served in place of it. Say so when we can spot
+	// it, so the error doesn't read as though a real feed failed to parse. The
+	// wrapped error keeps errors.Is(err, ErrFeedTypeNotDetected) working.
+	if looksLikeHTML(prefix) {
+		return nil, fmt.Errorf("%w: got an HTML document, not a feed (the server likely returned an error, login, or bot-protection page)", ErrFeedTypeNotDetected)
+	}
 	return nil, ErrFeedTypeNotDetected
+}
+
+// looksLikeHTML reports whether data begins with an HTML document rather than a
+// feed. It inspects the same leading bytes used for feed detection and is used
+// only to make the "not a feed" error clearer, never to parse anything.
+// Recognized starts are an HTML doctype and the html/head/body root elements,
+// which covers the pages most often returned in place of a feed. An HTML
+// comment (<!-- -->) is deliberately not treated as HTML, since feeds can begin
+// with one.
+func looksLikeHTML(data []byte) bool {
+	// Skip the same leading whitespace and byte order marks DetectFeedType
+	// does, so an indented or BOM-prefixed page is still recognized.
+	trimmed := bytes.TrimLeft(data, " \r\n\t\x00\xEF\xBB\xBF\xFE\xFF")
+
+	// Lowercase a short, bounded prefix for a case-insensitive match; only the
+	// opening tag matters, so a small window is plenty and avoids copying a
+	// large buffer.
+	const window = 64
+	if len(trimmed) > window {
+		trimmed = trimmed[:window]
+	}
+	head := strings.ToLower(string(trimmed))
+
+	if strings.HasPrefix(head, "<!doctype html") {
+		return true
+	}
+	return startsWithTag(head, "html") ||
+		startsWithTag(head, "head") ||
+		startsWithTag(head, "body")
+}
+
+// startsWithTag reports whether head opens with the given tag name, requiring a
+// tag delimiter after it so that, e.g., "html" matches <html> and <html lang>
+// but not a <htmlish> element.
+func startsWithTag(head, tag string) bool {
+	if !strings.HasPrefix(head, "<"+tag) {
+		return false
+	}
+	rest := head[1+len(tag):]
+	if rest == "" {
+		return true
+	}
+	switch rest[0] {
+	case ' ', '\t', '\r', '\n', '>', '/':
+		return true
+	}
+	return false
 }
 
 // ParseURL fetches the contents of a given url and

--- a/parser_test.go
+++ b/parser_test.go
@@ -433,3 +433,54 @@ func TestParser_Parse_RootBeyondDetectionWindow(t *testing.T) {
 	_, err := gofeed.NewParser().Parse(strings.NewReader(pad + `<rss version="2.0"><channel></channel></rss>`))
 	assert.ErrorIs(t, err, gofeed.ErrFeedTypeNotDetected)
 }
+
+// An HTML page served in place of a feed — a login wall, error page, or
+// bot-protection challenge — should report that it wasn't a feed, while still
+// matching ErrFeedTypeNotDetected for callers that check for it (issue #294).
+func TestParser_Parse_HTMLNotFeed(t *testing.T) {
+	pages := []string{
+		"<!DOCTYPE html>\n<html><head><title>Log in</title></head><body>Please sign in</body></html>",
+		`<html lang="en"><body>403 Forbidden</body></html>`,
+		"\n  \t<HTML>\n<BODY>Checking your browser...</BODY>\n</HTML>",
+		"\uFEFF<!doctype html><html></html>",
+		"<head><meta charset=\"utf-8\"></head>",
+	}
+	for _, page := range pages {
+		_, err := gofeed.NewParser().Parse(strings.NewReader(page))
+		assert.ErrorIs(t, err, gofeed.ErrFeedTypeNotDetected)
+		assert.Contains(t, err.Error(), "HTML", "page %q should be reported as HTML", page)
+	}
+}
+
+// A non-feed payload that isn't recognizably HTML keeps the plain
+// ErrFeedTypeNotDetected, with no invented HTML detail. In particular a
+// document that merely begins with an XML comment, or an element whose name
+// only starts with "html", must not be mistaken for an HTML page (issue #294).
+func TestParser_Parse_NonHTMLNotFeed(t *testing.T) {
+	inputs := []string{
+		"<note><to>Tove</to><from>Jani</from></note>",
+		"<!-- just a comment --><data>value</data>",
+		"<htmlish>not actually html</htmlish>",
+		"plain text, not markup at all",
+	}
+	for _, in := range inputs {
+		_, err := gofeed.NewParser().Parse(strings.NewReader(in))
+		assert.ErrorIs(t, err, gofeed.ErrFeedTypeNotDetected)
+		assert.NotContains(t, err.Error(), "HTML", "input %q should not be reported as HTML", in)
+	}
+}
+
+// The real-world case from the issue: a server answers with 2xx but hands back
+// an HTML challenge page instead of the feed. ParseURL should surface the
+// clearer "not a feed" error rather than a bare detection failure (issue #294).
+func TestParser_ParseURL_HTMLBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		io.WriteString(w, "<!DOCTYPE html><html><body>Just a moment...</body></html>")
+	}))
+	defer srv.Close()
+
+	_, err := gofeed.NewParser().ParseURL(srv.URL)
+	assert.ErrorIs(t, err, gofeed.ErrFeedTypeNotDetected)
+	assert.Contains(t, err.Error(), "HTML")
+}


### PR DESCRIPTION
Closes #294.

When the fetched body isn't a recognizable feed, `Parse` returns "failed to detect feed type". As the issue notes, in practice the usual cause isn't a malformed feed at all but the server handing back something else in place of it: a 403 page, a login wall, or a bot-protection challenge (the Figshare 202-with-HTML case from #129 is a good example). The bare message reads as though a real feed failed to parse, which sends people looking in the wrong direction.

This takes the first option from the issue: when detection fails, check whether the input opens with an HTML document (an `<!doctype html>`, or an `<html>`/`<head>`/`<body>` root, over the same leading bytes and BOM handling detection already uses) and, if so, say the response was an HTML page rather than a feed. The check is deliberately narrow so it can't mislabel something that isn't clearly HTML — an XML comment or an element whose name merely starts with "html" is left alone and keeps the plain error. Everything still wraps `ErrFeedTypeNotDetected`, so `errors.Is` checks are unaffected and nothing that isn't HTML changes behavior.

Since this covers the payload rather than the transport, it helps `Parse` and `ParseURL` alike, including the 2xx-with-HTML case that slips past the existing status check. Tests cover the HTML variants, the non-HTML negatives, and the ParseURL path; `go test -race -shuffle=on ./...`, `go vet`, and `staticcheck` all pass.