### PR TITLE
docs: add inspect.software health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gofeed
 
-[![CI](https://github.com/mmcdole/gofeed/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/mmcdole/gofeed/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/mmcdole/gofeed/branch/master/graph/badge.svg)](https://codecov.io/gh/mmcdole/gofeed) [![Go Reference](https://pkg.go.dev/badge/github.com/mmcdole/gofeed.svg)](https://pkg.go.dev/github.com/mmcdole/gofeed) [![License](http://img.shields.io/:license-mit-blue.svg)](http://doge.mit-license.org)
+[![CI](https://github.com/mmcdole/gofeed/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/mmcdole/gofeed/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/mmcdole/gofeed/branch/master/graph/badge.svg)](https://codecov.io/gh/mmcdole/gofeed) [![Go Reference](https://pkg.go.dev/badge/github.com/mmcdole/gofeed.svg)](https://pkg.go.dev/github.com/mmcdole/gofeed) [![inspect.software](https://raw.githubusercontent.com/inspect-software/badges/main/v1/m/mmcdole/gofeed.svg)](https://inspect.software/software/mmcdole/gofeed) [![License](http://img.shields.io/:license-mit-blue.svg)](http://doge.mit-license.org)
 
 # Gofeed: A Robust Feed Parser for Golang
 


### PR DESCRIPTION
This PR adds the [inspect.software](https://inspect.software) health badge to the README.

**Why this PR?**
Your project ranks in the upper rating bands of our open-source health index (which measures maintainability, responsiveness, and security). This badge makes that standing objectively visible to your users. Our index is a free public good, and scores cannot be bought.

**Technical details:**
- **No tracking:** Static SVG served via GitHub's CDN. No JavaScript, no third-party tracking.
- **No maintenance:** The badge updates automatically after every inspection.
- **Transparent:** Links directly to [your full report](https://inspect.software/software/mmcdole/gofeed), based on our open [methodology](https://inspect.software/methodology).

If you prefer to keep your README minimal, feel free to close this PR without replying. Your report will remain publicly available and up-to-date either way.
