### PR TITLE
Tolerate an unknown default namespace on the RSS root

### DIFF
--- a/internal/shared/extparser.go
+++ b/internal/shared/extparser.go
@@ -34,6 +34,13 @@ func IsExtension(p *xpp.Parser, nativeNamespaces ...string) bool {
 	return !InNamespace(p, nativeNamespaces...)
 }
 
+// IsCanonicalNamespace reports whether space is a recognized extension
+// namespace (one with a canonical prefix).
+func IsCanonicalNamespace(space string) bool {
+	_, ok := canonicalNamespaces[strings.TrimSpace(space)]
+	return ok
+}
+
 // ParseExtension parses the current element of the
 // XMLPullParser as an extension element and updates
 // the extension map

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -53,18 +53,28 @@ func (rp *Parser) parseRoot(p *xpp.Parser) (*Feed, error) {
 
 	ver := rp.parseVersion(p)
 
+	// Some feeds stamp a bogus default namespace on <rss>, which every
+	// unprefixed core element then inherits. Treat the root's own resolved
+	// namespace as native for this parse — unless it is a recognized
+	// extension namespace, which keeps deliberate foreign content (Atom,
+	// Dublin Core, ...) routed through extension handling.
+	native := nativeNamespaces
+	if space := strings.TrimSpace(p.Space()); space != "" && !shared.IsCanonicalNamespace(space) {
+		native = append([]string{space}, nativeNamespaces...)
+	}
+
 	err := shared.ForEachChild(p, func(name string) error {
 		// Skip any extensions found in the feed root.
-		if shared.IsExtension(p, nativeNamespaces...) {
+		if shared.IsExtension(p, native...) {
 			return p.Skip()
 		}
 		var err error
 		switch name {
 		case "channel":
-			channel, err = rp.parseChannel(p)
+			channel, err = rp.parseChannel(p, native)
 		case "item":
 			var item *Item
-			if item, err = rp.parseItem(p); err == nil {
+			if item, err = rp.parseItem(p, native); err == nil {
 				items = append(items, item)
 			}
 		case "textinput":
@@ -107,7 +117,7 @@ func (rp *Parser) parseRoot(p *xpp.Parser) (*Feed, error) {
 	return channel, nil
 }
 
-func (rp *Parser) parseChannel(p *xpp.Parser) (rss *Feed, err error) {
+func (rp *Parser) parseChannel(p *xpp.Parser, native []string) (rss *Feed, err error) {
 	if err = p.Expect(xpp.StartTag, "channel"); err != nil {
 		return nil, err
 	}
@@ -131,7 +141,7 @@ func (rp *Parser) parseChannel(p *xpp.Parser) (rss *Feed, err error) {
 	}
 
 	err = shared.ForEachChild(p, func(name string) error {
-		if shared.IsExtension(p, nativeNamespaces...) {
+		if shared.IsExtension(p, native...) {
 			extensions, err = shared.ParseExtension(extensions, p)
 			return err
 		}
@@ -175,7 +185,7 @@ func (rp *Parser) parseChannel(p *xpp.Parser) (rss *Feed, err error) {
 			rss.SkipDays, err = rp.parseSkipDays(p)
 		case "item":
 			var item *Item
-			if item, err = rp.parseItem(p); err == nil {
+			if item, err = rp.parseItem(p, native); err == nil {
 				rss.Items = append(rss.Items, item)
 			}
 		case "cloud":
@@ -227,7 +237,7 @@ func (rp *Parser) parseChannel(p *xpp.Parser) (rss *Feed, err error) {
 	return rss, nil
 }
 
-func (rp *Parser) parseItem(p *xpp.Parser) (item *Item, err error) {
+func (rp *Parser) parseItem(p *xpp.Parser, native []string) (item *Item, err error) {
 	if err = p.Expect(xpp.StartTag, "item"); err != nil {
 		return nil, err
 	}
@@ -246,7 +256,7 @@ func (rp *Parser) parseItem(p *xpp.Parser) (item *Item, err error) {
 			item.Content, err = shared.ParseText(p)
 			return err
 		}
-		if shared.IsExtension(p, nativeNamespaces...) {
+		if shared.IsExtension(p, native...) {
 			extensions, err = shared.ParseExtension(extensions, p)
 			return err
 		}

--- a/rss/parser_test.go
+++ b/rss/parser_test.go
@@ -54,6 +54,16 @@ func TestParser_Parse_CloudTruncated(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestParser_Parse_KnownForeignRootNamespace(t *testing.T) {
+	// Only an unrecognized root default namespace is tolerated as RSS
+	// core; a recognized extension namespace keeps its meaning, so this
+	// channel stays foreign and is skipped.
+	feed := `<rss version="2.0" xmlns="http://www.w3.org/2005/Atom"><channel><title>x</title></channel></rss>`
+	f, err := (&rss.Parser{}).Parse(strings.NewReader(feed))
+	assert.NoError(t, err)
+	assert.Empty(t, f.Title)
+}
+
 // TODO: Examples
 
 func TestParser_Parse_UnknownRoot(t *testing.T) {

--- a/testdata/parser/rss/issue_346_root_default_namespace.json
+++ b/testdata/parser/rss/issue_346_root_default_namespace.json
@@ -1,0 +1,50 @@
+{
+  "title": "suspilne.news",
+  "link": "https://suspilne.media/",
+  "links": [
+    "https://suspilne.media/"
+  ],
+  "description": "Новини України від редакції Суспільне | Новини.",
+  "pubDate": "Fri, 22 Dec 2023 01:04:55 +0200",
+  "pubDateParsed": "2023-12-21T23:04:55Z",
+  "ttl": "5",
+  "extensions": {
+    "atom": {
+      "link": [
+        {
+          "name": "link",
+          "value": "",
+          "attrs": {
+            "href": "https://suspilne.media/rss/ukrnet.rss?",
+            "rel": "self",
+            "type": "application/rss+xml"
+          },
+          "children": {}
+        }
+      ]
+    }
+  },
+  "items": [
+    {
+      "title": "Торгівля між Росією та Китаєм у 2023 році перевищила 200 млрд доларів — New York Times",
+      "link": "https://suspilne.media/645026-torgivla-miz-rosieu-ta-kitaem-u-2023-roci-perevisila-200-mlrd-dolariv-new-york-times/",
+      "links": [
+        "https://suspilne.media/645026-torgivla-miz-rosieu-ta-kitaem-u-2023-roci-perevisila-200-mlrd-dolariv-new-york-times/"
+      ],
+      "description": "Торгівля між РФ та КНР перевищила 200 млрд доларів за 2023 рік.",
+      "pubDate": "Fri, 22 Dec 2023 01:04:55 +0200",
+      "pubDateParsed": "2023-12-21T23:04:55Z"
+    },
+    {
+      "title": "У Гаазі проходить масштабна конференція",
+      "link": "https://suspilne.media/644990-u-gaazi-prohodit-masstabna-konferencia/",
+      "links": [
+        "https://suspilne.media/644990-u-gaazi-prohodit-masstabna-konferencia/"
+      ],
+      "description": "Конференція у Гаазі.",
+      "pubDate": "Fri, 22 Dec 2023 00:30:00 +0200",
+      "pubDateParsed": "2023-12-21T22:30:00Z"
+    }
+  ],
+  "version": "2.0"
+}

--- a/testdata/parser/rss/issue_346_root_default_namespace.xml
+++ b/testdata/parser/rss/issue_346_root_default_namespace.xml
@@ -1,0 +1,27 @@
+<!--
+Description: the reporter's feed declares a bogus default namespace on
+<rss> which every unprefixed core element inherits; those elements must
+still parse as RSS core while atom:link stays an extension (issue #346).
+-->
+<rss xmlns="https://cyber.harvard.edu/rss/rss.html" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+  <channel>
+    <title><![CDATA[suspilne.news]]></title>
+    <link>https://suspilne.media/</link>
+    <atom:link href="https://suspilne.media/rss/ukrnet.rss?" rel="self" type="application/rss+xml"/>
+    <description><![CDATA[Новини України від редакції Суспільне | Новини.]]></description>
+    <pubDate>Fri, 22 Dec 2023 01:04:55 +0200</pubDate>
+    <ttl>5</ttl>
+    <item>
+      <title><![CDATA[Торгівля між Росією та Китаєм у 2023 році перевищила 200 млрд доларів — New York Times]]></title>
+      <link>https://suspilne.media/645026-torgivla-miz-rosieu-ta-kitaem-u-2023-roci-perevisila-200-mlrd-dolariv-new-york-times/</link>
+      <description><![CDATA[Торгівля між РФ та КНР перевищила 200 млрд доларів за 2023 рік.]]></description>
+      <pubDate>Fri, 22 Dec 2023 01:04:55 +0200</pubDate>
+    </item>
+    <item>
+      <title><![CDATA[У Гаазі проходить масштабна конференція]]></title>
+      <link>https://suspilne.media/644990-u-gaazi-prohodit-masstabna-konferencia/</link>
+      <description><![CDATA[Конференція у Гаазі.]]></description>
+      <pubDate>Fri, 22 Dec 2023 00:30:00 +0200</pubDate>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
Since #339 the RSS parser classifies elements by their resolved namespace against a fixed whitelist. A feed that declares a default namespace on `<rss>` (like `xmlns="https://cyber.harvard.edu/rss/rss.html"`) puts every unprefixed core element in that namespace, so `channel` and everything under it got skipped as an extension and the parse returned an empty feed with no error.

The root's own namespace is now treated as native for that parse, unless it is a recognized extension namespace. Namespaces introduced further down still resolve normally, so Atom self/hub links embedded in RSS keep their metadata (the #338 shape).

Adds a fixture pair built from the reported feed, plus a test that a recognized namespace (Atom) on the root is not aliased.

Fixes #346