### PR TITLE
Detect JSON feeds larger than the sniffing window

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -2,7 +2,6 @@ package gofeed
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"strings"
 
@@ -25,10 +24,10 @@ const (
 	FeedTypeJSON
 )
 
-// DetectFeedType attempts to determine the type of feed
-// by looking for specific xml elements unique to the
-// various feed types. It returns FeedTypeUnknown when the
-// reader fails before the type can be determined.
+// DetectFeedType attempts to determine the type of feed by looking for an XML
+// root element or the start of a JSON object. It does not validate the entire
+// document; the selected format parser performs full validation. It returns
+// FeedTypeUnknown when the reader fails before the type can be determined.
 func DetectFeedType(feed io.Reader) FeedType {
 	buffer := new(bytes.Buffer)
 	if _, err := buffer.ReadFrom(feed); err != nil {
@@ -74,10 +73,7 @@ loop:
 			return FeedTypeUnknown
 		}
 	} else if firstChar == '{' {
-		// Check if document is valid JSON
-		if json.Valid(buffer.Bytes()) {
-			return FeedTypeJSON
-		}
+		return FeedTypeJSON
 	}
 	return FeedTypeUnknown
 }

--- a/detector_test.go
+++ b/detector_test.go
@@ -68,3 +68,10 @@ func TestDetectFeedType_ReaderError(t *testing.T) {
 	r := io.MultiReader(strings.NewReader(`<rss version="2.0"></rss>`), iotest.ErrReader(errors.New("boom")))
 	assert.Equal(t, gofeed.FeedTypeUnknown, gofeed.DetectFeedType(r))
 }
+
+// JSON detection must work from a bounded prefix; the JSON parser validates
+// the complete document after detection (issue #344).
+func TestDetectFeedType_JSONPrefix(t *testing.T) {
+	prefix := `{"version":"https://jsonfeed.org/version/1.1","items":[{`
+	assert.Equal(t, gofeed.FeedTypeJSON, gofeed.DetectFeedType(strings.NewReader(prefix)))
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,6 +3,7 @@ package gofeed_test
 import (
 	"bytes"
 	"context"
+	stdjson "encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -424,6 +425,38 @@ func TestParser_Parse_LargeFeed(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, feed.Items, 2000)
 	assert.Equal(t, "item 1999", feed.Items[1999].Title)
+}
+
+// JSON feeds larger than the detection window must be classified from their
+// prefix and then validated and decoded from the complete stream (issue #344).
+func TestParser_Parse_LargeJSONFeed(t *testing.T) {
+	content := strings.Repeat("x", 8192)
+	body := fmt.Sprintf(
+		`{"version":"https://jsonfeed.org/version/1.1","title":"big","items":[{"id":"1","content_text":%q}]}`,
+		content,
+	)
+
+	feed, err := gofeed.NewParser().Parse(strings.NewReader(body))
+	assert.NoError(t, err)
+	if assert.NotNil(t, feed) && assert.Len(t, feed.Items, 1) {
+		assert.Equal(t, "json", feed.FeedType)
+		assert.Equal(t, "big", feed.Title)
+		assert.Equal(t, content, feed.Items[0].Content)
+	}
+}
+
+// Once a large JSON document is detected, syntax errors beyond the detection
+// window must come from the JSON parser rather than being masked as a type
+// detection failure.
+func TestParser_Parse_LargeMalformedJSON(t *testing.T) {
+	body := `{"version":"https://jsonfeed.org/version/1.1","items":[{"id":"1","content_text":"` +
+		strings.Repeat("x", 8192) + `"}`
+
+	feed, err := gofeed.NewParser().Parse(strings.NewReader(body))
+	assert.Nil(t, feed)
+	var syntaxError *stdjson.SyntaxError
+	assert.ErrorAs(t, err, &syntaxError)
+	assert.NotErrorIs(t, err, gofeed.ErrFeedTypeNotDetected)
 }
 
 // Detection only inspects the first few KB; a root element pushed beyond


### PR DESCRIPTION
Fixes #344.

Parse deliberately inspects only a bounded prefix so XML feeds can continue streaming. JSON detection previously required that prefix to be a complete valid document, which made every JSON Feed larger than 4096 bytes undetectable.

Treat an opening JSON object as sufficient for format detection and leave complete syntax validation to the JSON parser. This matches the existing XML detector/parser split, avoids duplicate validation, preserves reader error propagation, and lets malformed JSON return its actual syntax error instead of ErrFeedTypeNotDetected.

Tests cover a valid JSON Feed larger than the detection window, a malformed large document whose error occurs beyond the window, and detection from an incomplete JSON prefix.