### PR TITLE
Reduce allocations when parsing dates with named zones

### DIFF
--- a/internal/shared/dateparser.go
+++ b/internal/shared/dateparser.go
@@ -219,20 +219,63 @@ var timezoneAbbreviations = map[string]int{
 	"EEST": 3 * 3600,
 }
 
+// endsInZoneAbbreviation reports whether d ends in a bare uppercase timezone
+// abbreviation, in a shape that no layout in dateFormats can match.
+//
+// Three to five characters follows time.parseTimeZone's internal rule, and it also
+// excludes every trailing alphabetic token dateFormats layouts end in ("UT"/"Z"/"PM").
+// The only overlap left is a zone name after a numeric offset ("-0700 MST" and its
+// "GMT" sibling),hence the check on the field in front.
+func endsInZoneAbbreviation(d string) bool {
+	i := len(d)
+	for i > 0 && d[i-1] >= 'A' && d[i-1] <= 'Z' {
+		i--
+	}
+	// i == 0 means the whole string is letters, so it carries no date at all.
+	if n := len(d) - i; i == 0 || n < 3 || n > 5 {
+		return false
+	}
+
+	head := strings.TrimRight(d[:i], " ")
+	if j := strings.LastIndexByte(head, ' '); j >= 0 {
+		head = head[j+1:]
+	}
+	return !strings.HasPrefix(head, "+") && !strings.HasPrefix(head, "-")
+}
+
 // ParseDate parses a given date string using a large
 // list of commonly found feed date formats.
-func ParseDate(ds string) (t time.Time, err error) {
+func ParseDate(ds string) (time.Time, error) {
 	d := strings.TrimSpace(ds)
 	if d == "" {
-		return t, fmt.Errorf("date string is empty")
+		return time.Time{}, fmt.Errorf("date string is empty")
 	}
-	for _, f := range dateFormats {
-		if t, err = time.Parse(f, d); err == nil {
-			return
+	// A date ending in a bare zone abbreviation cannot match dateFormats, so
+	// look at the named-zone layouts first. Only the order changes: both lists
+	// are still tried, so a wrong guess costs time and nothing else.
+	namedZoneFirst := endsInZoneAbbreviation(d)
+	if namedZoneFirst {
+		if t, ok := parseNamedZone(d); ok {
+			return t, nil
 		}
 	}
+	for _, f := range dateFormats {
+		if t, err := time.Parse(f, d); err == nil {
+			return t, nil
+		}
+	}
+	if !namedZoneFirst {
+		if t, ok := parseNamedZone(d); ok {
+			return t, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("failed to parse date: %s", ds)
+}
+
+func parseNamedZone(d string) (time.Time, bool) {
 	for _, f := range dateFormatsWithNamedZone {
-		t, err = time.Parse(f, d)
+		t, err := time.Parse(f, d)
 		if err != nil {
 			continue
 		}
@@ -248,9 +291,8 @@ func ParseDate(ds string) (t time.Time, err error) {
 					t.Minute(), t.Second(), t.Nanosecond(), time.FixedZone(name, want))
 			}
 		}
-		return t, nil
+		return t, true
 	}
 
-	err = fmt.Errorf("failed to parse date: %s", ds)
-	return
+	return time.Time{}, false
 }

--- a/internal/shared/dateparser_test.go
+++ b/internal/shared/dateparser_test.go
@@ -79,3 +79,40 @@ func TestDateLayoutsRoundTrip(t *testing.T) {
 		}
 	}
 }
+
+// Guards ParseDate's dispatch. UTC covers the layouts whose zone token is a
+// literal "Z" or an RFC3339 "Z07:00"; a named zone covers the ones that end in
+// a real abbreviation.
+func TestNumericLayoutsNeverEndInZone(t *testing.T) {
+	ref := time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC)
+	for _, zone := range []*time.Location{time.UTC, time.FixedZone("MST", -7*3600)} {
+		for _, layout := range dateFormats {
+			if s := ref.In(zone).Format(layout); endsInZoneAbbreviation(s) {
+				t.Errorf("layout %q renders %q, which ParseDate would match against the named-zone layouts first", layout, s)
+			}
+		}
+	}
+}
+
+func BenchmarkParseDate(b *testing.B) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"NamedZoneGMT", "Mon, 10 Aug 2026 10:00:00 GMT"},
+		{"NumericOffset", "Mon, 10 Aug 2026 10:00:00 +0000"},
+		{"RFC3339", "2026-08-10T10:00:00Z"},
+		{"Unparseable", "not a date at all"},
+		// Worst case for the dispatch: the predicate fires, so both lists are
+		// exhausted in the reordered order.
+		{"UnparseableZoneTail", "Mon, 99 Xyz 2026 99:99:99 QQQ"},
+	}
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_, _ = ParseDate(c.in)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #351

More information on the problem in the issue. Basically, parsing dates is expensive, and in the specific case of named zones it was particularly bad. A GMT time required failing 124 `time.Parse` calls. Found via pprof on a real feed reader: `time.newParseError` was 38.7% of all allocations during feed parsing, `time.parse` 13.2% of CPU.

This commit only affects the order. It tries to do a quicker check on whether the time has a named zone, and if it does it tries that list first. Note both lists are still tried, so there is no risk of regression, the same lists are tested.

Some more notes:

- Go's zone parser rejects abbreviations shorter than three characters. That's what keeps the trailing UT and Z literals and the PM/pm meridiems on the numeric path: they're two characters, so the predicate never fires.
- The one real overlap is a zone name following a numeric offset (`Mon, 2 Jan 2006 15:04:05 -0700 MST` and its GMT sibling) which the offset guard excludes.
- `TestNumericLayoutsNeverEndInZone` enforces this by rendering every dateFormats layout in UTC and in a named zone  and asserting the predicate rejects the result. Nothing is hand-maintained: an alpha-terminated layout added to dateFormats fails that test.

## Verification

Besides the basics (test, vet, etc), added some more tests and a benchmark to verify the change (let me know if you want me to drop it).

I did not commit it because it seems very overkill, but I did have an LLM write [this test](https://github.com/guille/gofeed/commit/3432297ce34b240ad18db75418a0b5587e6f6593) to run an exhaustive verification test with the old vs new implementations, fuzzing included. I'm fairly sure there are no regressions here!

### Performance

The benchmark included in this PR:

```
BenchmarkParseDate, benchstat -count 6:

                            │   before     │              after                │
ParseDate/NamedZoneGMT-8      11297.0n ± 2%   289.9n ± 3%   -97.43% (p=0.002 n=6)
ParseDate/NumericOffset-8       316.8n ± 3%   322.9n ± 2%         ~ (p=0.100 n=6)
ParseDate/RFC3339-8             82.45n ± 2%   85.92n ± 2%    +4.20% (p=0.004 n=6)
ParseDate/Unparseable-8         10.67µ ± 2%   10.72µ ± 2%         ~ (p=0.394 n=6)
ParseDate/UnparseableZoneTail-8 12.82µ ± 1%   12.89µ ± 2%         ~ (p=0.310 n=6)

                            │  allocs/op   │  allocs/op   vs base              │
ParseDate/NamedZoneGMT-8        383.000 ± 0%    4.000 ± 0%  -98.96% (p=0.002 n=6)
ParseDate/NumericOffset-8         9.000 ± 0%    9.000 ± 0%        ~ (all equal)
ParseDate/RFC3339-8               3.000 ± 0%    3.000 ± 0%        ~ (all equal)
ParseDate/Unparseable-8            522.0 ± 0%  al)
ParseDate/UnparseableZoneTail-8    522.0 ± 0%    522.0 ± 0%       ~ (all equal)

B/op on NamedZoneGMT: 17376 → 163 (-99.06%)  
```

Note the RFC3339 case is the one exception that does get (slightly!) slower after the change

I also linked the patched gofeed into a real feed reader via go.work and parsed a 100-item RSS document with GMT dates and 4 KB HTML bodies:

Metric | before (v1.4.2) | after (local gofeed)
-- | -- | --
allocs/op | 100.68k ± 0% | 62.78k ± 0% (−37.6%, p=0.000)
B/op | 8.382Mi ± 0% | 6.740Mi ± 0% (−19.6%, p=0.000)
sec/op | 11.265m ± 2% | 9.754m ± 2% (−13.4%, p=0.000)

I am aware the code gets more complex and you're the maintainer, so no hard feelings if you decide the change is not worth it, or if you can think of a neater way to get similar results.