### PR TITLE
Reject null JSON feed items and authors

### DIFF
--- a/json/coerce.go
+++ b/json/coerce.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -37,6 +38,23 @@ func (f *Feed) UnmarshalJSON(data []byte) error {
 	}{alias: (*alias)(f)}
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
+	}
+	// Null array elements decode as nil pointers, which cannot be translated
+	// into items or people. Null optional fields and null arrays remain accepted.
+	for i, author := range f.Authors {
+		if author == nil {
+			return fmt.Errorf("gofeed: JSON feed authors[%d] must not be null", i)
+		}
+	}
+	for i, item := range f.Items {
+		if item == nil {
+			return fmt.Errorf("gofeed: JSON feed items[%d] must not be null", i)
+		}
+		for j, author := range item.Authors {
+			if author == nil {
+				return fmt.Errorf("gofeed: JSON feed items[%d].authors[%d] must not be null", i, j)
+			}
+		}
 	}
 	f.Expired = coerceBool(aux.Expired)
 	return nil

--- a/parser_test.go
+++ b/parser_test.go
@@ -18,10 +18,62 @@ import (
 
 	"github.com/mmcdole/gofeed"
 	"github.com/mmcdole/gofeed/internal/testutil"
+	jsonfeed "github.com/mmcdole/gofeed/json"
 	"github.com/mmcdole/gofeed/rss"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestParser_NullJSONElements(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"first_item", "items[0]"},
+		{"later_item", "items[1]"},
+		{"first_author", "authors[0]"},
+		{"later_author", "authors[1]"},
+		{"first_item_author", "items[0].authors[0]"},
+		{"later_item_author", "items[1].authors[1]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data := testutil.ReadFile(t, "testdata/parser/json/invalid/issue_355_"+tc.name+".json")
+			want := "gofeed: JSON feed " + tc.path + " must not be null"
+			t.Run("json", func(t *testing.T) {
+				feed, err := (&jsonfeed.Parser{}).Parse(bytes.NewReader(data))
+				require.EqualError(t, err, want)
+				require.Nil(t, feed)
+			})
+			t.Run("universal", func(t *testing.T) {
+				feed, err := gofeed.NewParser().Parse(bytes.NewReader(data))
+				require.EqualError(t, err, want)
+				require.Nil(t, feed)
+			})
+		})
+	}
+}
+
+func TestParser_NullOptionalJSONFields(t *testing.T) {
+	for _, items := range []string{"null", `[{"id":"a","content_text":"text","author":null,"authors":null}]`} {
+		t.Run(items, func(t *testing.T) {
+			data := `{"version":"https://jsonfeed.org/version/1.1","title":"Null fields","author":null,"authors":null,"items":` + items + `}`
+			feed, err := gofeed.NewParser().ParseString(data)
+			require.NoError(t, err)
+			require.NotNil(t, feed)
+			require.Nil(t, feed.Author)
+			require.Nil(t, feed.Authors)
+			if items == "null" {
+				require.Empty(t, feed.Items)
+			} else {
+				require.Len(t, feed.Items, 1)
+				require.Equal(t, "a", feed.Items[0].GUID)
+				require.Equal(t, "text", feed.Items[0].Content)
+				require.Nil(t, feed.Items[0].Author)
+				require.Nil(t, feed.Items[0].Authors)
+			}
+		})
+	}
+}
 
 func TestParser_Parse(t *testing.T) {
 	var feedTests = []struct {

--- a/testdata/parser/json/invalid/issue_355_first_author.json
+++ b/testdata/parser/json/invalid/issue_355_first_author.json
@@ -1,0 +1,8 @@
+{
+  "version": "https://jsonfeed.org/version/1.1",
+  "title": "Null elements",
+  "authors": [
+    null
+  ],
+  "items": []
+}

--- a/testdata/parser/json/invalid/issue_355_first_item.json
+++ b/testdata/parser/json/invalid/issue_355_first_item.json
@@ -1,0 +1,7 @@
+{
+  "version": "https://jsonfeed.org/version/1.1",
+  "title": "Null elements",
+  "items": [
+    null
+  ]
+}

--- a/testdata/parser/json/invalid/issue_355_first_item_author.json
+++ b/testdata/parser/json/invalid/issue_355_first_item_author.json
@@ -1,0 +1,13 @@
+{
+  "version": "https://jsonfeed.org/version/1.1",
+  "title": "Null elements",
+  "items": [
+    {
+      "id": "a",
+      "content_text": "text",
+      "authors": [
+        null
+      ]
+    }
+  ]
+}

--- a/testdata/parser/json/invalid/issue_355_later_author.json
+++ b/testdata/parser/json/invalid/issue_355_later_author.json
@@ -1,0 +1,11 @@
+{
+  "version": "https://jsonfeed.org/version/1.1",
+  "title": "Null elements",
+  "authors": [
+    {
+      "name": "Alice"
+    },
+    null
+  ],
+  "items": []
+}

--- a/testdata/parser/json/invalid/issue_355_later_item.json
+++ b/testdata/parser/json/invalid/issue_355_later_item.json
@@ -1,0 +1,11 @@
+{
+  "version": "https://jsonfeed.org/version/1.1",
+  "title": "Null elements",
+  "items": [
+    {
+      "id": "a",
+      "content_text": "text"
+    },
+    null
+  ]
+}

--- a/testdata/parser/json/invalid/issue_355_later_item_author.json
+++ b/testdata/parser/json/invalid/issue_355_later_item_author.json
@@ -1,0 +1,20 @@
+{
+  "version": "https://jsonfeed.org/version/1.1",
+  "title": "Null elements",
+  "items": [
+    {
+      "id": "a",
+      "content_text": "text"
+    },
+    {
+      "id": "b",
+      "content_text": "text",
+      "authors": [
+        {
+          "name": "Alice"
+        },
+        null
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Return an error when JSON feed items or authors arrays contain null elements, instead of panicking during translation. Errors identify the array position. Null optional fields and null arrays remain accepted.

Adds fixtures for null elements at the first and later positions in items, feed authors, and item authors. Tests cover both parsers and existing null-field behavior.

Build, vet, staticcheck, and race tests pass locally.

Fixes #355.
