### PR TITLE
Preserve file paths when resolving xml:base URLs

### DIFF
--- a/internal/shared/xmlbase.go
+++ b/internal/shared/xmlbase.go
@@ -105,17 +105,7 @@ func XmlBaseResolveUrl(b *url.URL, u string) (*url.URL, error) {
 		return relURL, nil
 	}
 
-	// Work on a copy: b is the live base held on the parser's stack, so
-	// appending "/" to it here would rewrite the base for every sibling
-	// resolved after the first relative URL in this scope.
-	base := *b
-	if base.Path != "" && u != "" && base.Path[len(base.Path)-1] != '/' {
-		// There's no reason someone would use a path in xml:base if they
-		// didn't mean for it to be a directory
-		base.Path = base.Path + "/"
-	}
-	absURL := base.ResolveReference(relURL)
-	return absURL, nil
+	return b.ResolveReference(relURL), nil
 }
 
 // ResolveURLIfBase resolves s against base when an xml:base is in scope,

--- a/internal/shared/xmlbase_test.go
+++ b/internal/shared/xmlbase_test.go
@@ -19,16 +19,31 @@ func TestXmlBaseResolveUrlDoesNotMutateBase(t *testing.T) {
 	}
 }
 
-// A directory-style resolution should still work (the path is treated as a
-// directory), just without mutating the input.
 func TestXmlBaseResolveUrlResolves(t *testing.T) {
-	base, _ := url.Parse("http://example.com/a/b")
-	got, err := XmlBaseResolveUrl(base, "x")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.String() != "http://example.com/a/b/x" {
-		t.Errorf("resolved = %q, want %q", got.String(), "http://example.com/a/b/x")
+	for _, tt := range []struct {
+		base string
+		ref  string
+		want string
+	}{
+		{"http://example.com/a/b", "x", "http://example.com/a/x"},
+		{"http://example.com/a/b/", "x", "http://example.com/a/b/x"},
+		{"http://example.com/a/b?old=1", "?new=2", "http://example.com/a/b?new=2"},
+		{"http://example.com/a/b?old=1", "#part", "http://example.com/a/b?old=1#part"},
+		{"http://example.com/a/b", "", "http://example.com/a/b"},
+	} {
+		t.Run(tt.base+"/"+tt.ref, func(t *testing.T) {
+			base, err := url.Parse(tt.base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := XmlBaseResolveUrl(base, tt.ref)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.String() != tt.want {
+				t.Errorf("resolved = %q, want %q", got.String(), tt.want)
+			}
+		})
 	}
 }
 

--- a/testdata/parser/atom/feed_logo_uri_base.json
+++ b/testdata/parser/atom/feed_logo_uri_base.json
@@ -1,5 +1,5 @@
 {
-    "icon": "http://example.org/img/icon.png",
+    "icon": "http://example.org/icon.png",
     "logo": "http://example.org/logo.png",
     "entries": [],
     "version": "1.0"

--- a/testdata/parser/atom/issue_358_xml_base_file.json
+++ b/testdata/parser/atom/issue_358_xml_base_file.json
@@ -1,0 +1,24 @@
+{
+    "links": [
+        {
+            "href": "https://example.com/feeds/post",
+            "rel": "alternate"
+        },
+        {
+            "href": "https://example.com/feeds/feed.xml?page=2",
+            "rel": "alternate"
+        }
+    ],
+    "entries": [
+        {
+            "links": [
+                {
+                    "href": "https://example.com/feeds/archive/post",
+                    "rel": "alternate"
+                }
+            ],
+            "summary": "<a href=\"https://example.com/feeds/archive/entry.xml#part\">Read</a>"
+        }
+    ],
+    "version": "1.0"
+}

--- a/testdata/parser/atom/issue_358_xml_base_file.xml
+++ b/testdata/parser/atom/issue_358_xml_base_file.xml
@@ -1,0 +1,8 @@
+<feed xmlns="http://www.w3.org/2005/Atom" xml:base="https://example.com/feeds/feed.xml">
+  <link href="post"/>
+  <link href="?page=2"/>
+  <entry xml:base="archive/entry.xml">
+    <link href="post"/>
+    <summary type="html">&lt;a href="#part"&gt;Read&lt;/a&gt;</summary>
+  </entry>
+</feed>

--- a/testdata/parser/rss/issue_358_xml_base_file.json
+++ b/testdata/parser/rss/issue_358_xml_base_file.json
@@ -1,0 +1,8 @@
+{
+    "items": [
+        {"link": "https://example.com/feeds/post", "links": ["https://example.com/feeds/post"]},
+        {"link": "https://example.com/feeds/archive/post", "links": ["https://example.com/feeds/archive/post"]},
+        {"link": "https://example.com/feeds/feed.xml#part", "links": ["https://example.com/feeds/feed.xml#part"]}
+    ],
+    "version": "2.0"
+}

--- a/testdata/parser/rss/issue_358_xml_base_file.xml
+++ b/testdata/parser/rss/issue_358_xml_base_file.xml
@@ -1,0 +1,7 @@
+<rss version="2.0" xml:base="https://example.com/feeds/feed.xml">
+  <channel>
+    <item><link>post</link></item>
+    <item xml:base="archive/"><link>post</link></item>
+    <item><link>#part</link></item>
+  </channel>
+</rss>


### PR DESCRIPTION
Resolve relative URLs against xml:base without appending a slash. A base of https://example.com/feeds/feed.xml now resolves post to https://example.com/feeds/post.

Adds RSS and Atom regression fixtures and corrects the existing icon fixture's expected URL. Build, vet, staticcheck, and race tests pass locally.

Fixes #358.
